### PR TITLE
Feat/create mover profile

### DIFF
--- a/src/common/validator/service.validator.ts
+++ b/src/common/validator/service.validator.ts
@@ -1,0 +1,25 @@
+import {
+  registerDecorator,
+  ValidationOptions,
+  ValidationArguments,
+} from 'class-validator';
+
+export function HasAtLeastOneTrue(validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: 'hasAtLeastOneTrue',
+      target: object.constructor,
+      propertyName,
+      options: validationOptions,
+      validator: {
+        validate(value: Record<string, boolean>, _: unknown): boolean {
+          if (typeof value !== 'object' || value === null) return false;
+          return Object.values(value).some((v) => v === true); // 1개 이상 true인지 확인
+        },
+        defaultMessage(args: ValidationArguments) {
+          return `${args.property} 객체에는 최소 하나 이상 선택되어야 합니다.`;
+        },
+      },
+    });
+  };
+}

--- a/src/mover-profile/dto/create-mover-profile.dto.ts
+++ b/src/mover-profile/dto/create-mover-profile.dto.ts
@@ -1,1 +1,29 @@
-export class CreateMoverProfileDto {}
+import { IsInt, IsObject, IsOptional, IsString } from 'class-validator';
+import {
+  ServiceRegionMap,
+  ServiceTypeMap,
+} from 'src/common/const/service.const';
+
+export class CreateMoverProfileDto {
+  @IsString()
+  nickname: string;
+
+  @IsOptional()
+  @IsString()
+  imageUrl?: string;
+
+  @IsInt()
+  experience: number;
+
+  @IsString()
+  intro: string;
+
+  @IsString()
+  description: string;
+
+  @IsObject()
+  serviceType: ServiceTypeMap;
+
+  @IsObject()
+  serviceRegion: ServiceRegionMap;
+}

--- a/src/mover-profile/dto/create-mover-profile.dto.ts
+++ b/src/mover-profile/dto/create-mover-profile.dto.ts
@@ -1,11 +1,26 @@
-import { IsInt, IsObject, IsOptional, IsString } from 'class-validator';
+import {
+  IsInt,
+  IsObject,
+  IsOptional,
+  IsString,
+  Length,
+  Matches,
+  Max,
+  Min,
+} from 'class-validator';
 import {
   ServiceRegionMap,
   ServiceTypeMap,
 } from 'src/common/const/service.const';
+import { HasAtLeastOneTrue } from 'src/common/validator/service.validator';
 
 export class CreateMoverProfileDto {
   @IsString()
+  @Length(2, 20, { message: '닉네임은 2자 이상 20자 이하여야 합니다.' })
+  @Matches(/^[가-힣a-zA-Z0-9]+$/, {
+    message:
+      '닉네임은 한글, 영문, 숫자만 사용할 수 있으며 공백 및 특수문자는 허용되지 않습니다.',
+  })
   nickname: string;
 
   @IsOptional()
@@ -13,17 +28,30 @@ export class CreateMoverProfileDto {
   imageUrl?: string;
 
   @IsInt()
+  @Min(0, { message: '경력은 최소 0이상 입력해야 합니다.' })
+  @Max(99, { message: '경력은 최대 99까지 입력해야 합니다.' })
   experience: number;
 
   @IsString()
+  @Length(8, 50, { message: '소개는 8자 이상 50자 이하 입니다.' })
+  @Matches(/^[^\r\n]*$/, {
+    message: '소개에는 줄바꿈을 포함할 수 없습니다.',
+  })
   intro: string;
 
   @IsString()
+  @Length(10, 500, { message: '설명은 10자 이상 500자 이하 입니다.' })
   description: string;
 
   @IsObject()
+  @HasAtLeastOneTrue({
+    message: '서비스 타입은 최소 하나 이상 선택되어야 합니다.',
+  })
   serviceType: ServiceTypeMap;
 
   @IsObject()
+  @HasAtLeastOneTrue({
+    message: '서비스 지역은 최소 하나 이상 선택되어야 합니다.',
+  })
   serviceRegion: ServiceRegionMap;
 }

--- a/src/mover-profile/mover-profile.controller.ts
+++ b/src/mover-profile/mover-profile.controller.ts
@@ -1,15 +1,30 @@
-import { Controller, Get, Post, Body, Patch, Param, Delete } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
 import { MoverProfileService } from './mover-profile.service';
 import { CreateMoverProfileDto } from './dto/create-mover-profile.dto';
 import { UpdateMoverProfileDto } from './dto/update-mover-profile.dto';
+import { RBAC } from 'src/auth/decorator/rbac.decorator';
+import { Role } from 'src/user/entities/user.entity';
+import { UserInfo } from 'src/user/decorator/user-info.decorator';
 
-@Controller('mover-profile')
+@Controller('mover')
 export class MoverProfileController {
   constructor(private readonly moverProfileService: MoverProfileService) {}
 
   @Post()
-  create(@Body() createMoverProfileDto: CreateMoverProfileDto) {
-    return this.moverProfileService.create(createMoverProfileDto);
+  @RBAC(Role.MOVER) // mover만 접근 가능, customer은 접근 불가
+  create(
+    @Body() createMoverProfileDto: CreateMoverProfileDto,
+    @UserInfo() userInfo: UserInfo,
+  ) {
+    return this.moverProfileService.create(createMoverProfileDto, userInfo);
   }
 
   @Get()
@@ -23,7 +38,10 @@ export class MoverProfileController {
   }
 
   @Patch(':id')
-  update(@Param('id') id: string, @Body() updateMoverProfileDto: UpdateMoverProfileDto) {
+  update(
+    @Param('id') id: string,
+    @Body() updateMoverProfileDto: UpdateMoverProfileDto,
+  ) {
     return this.moverProfileService.update(+id, updateMoverProfileDto);
   }
 

--- a/src/mover-profile/mover-profile.module.ts
+++ b/src/mover-profile/mover-profile.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
 import { MoverProfileService } from './mover-profile.service';
 import { MoverProfileController } from './mover-profile.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { MoverProfile } from './entities/mover-profile.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([MoverProfile])],
   controllers: [MoverProfileController],
   providers: [MoverProfileService],
 })

--- a/src/mover-profile/mover-profile.service.ts
+++ b/src/mover-profile/mover-profile.service.ts
@@ -1,11 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { CreateMoverProfileDto } from './dto/create-mover-profile.dto';
 import { UpdateMoverProfileDto } from './dto/update-mover-profile.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoverProfile } from './entities/mover-profile.entity';
+import { Repository } from 'typeorm';
+import { UserInfo } from 'src/user/decorator/user-info.decorator';
 
 @Injectable()
 export class MoverProfileService {
-  create(createMoverProfileDto: CreateMoverProfileDto) {
-    return 'This action adds a new moverProfile';
+  constructor(
+    @InjectRepository(MoverProfile)
+    private readonly moverProfileRepository: Repository<MoverProfile>,
+  ) {}
+
+  create(createMoverProfileDto: CreateMoverProfileDto, userInfo: UserInfo) {
+    const profile = {
+      user: { id: userInfo.sub }, // 관계 설정, 외래 키 자동 매핑
+      ...createMoverProfileDto,
+    };
+    return this.moverProfileRepository.save(profile);
   }
 
   findAll() {

--- a/src/user/decorator/user-info.decorator.ts
+++ b/src/user/decorator/user-info.decorator.ts
@@ -1,0 +1,28 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { Role } from '../entities/user.entity';
+
+export type UserInfo = {
+  sub: string; // 사용자 ID
+  role: Role; // 사용자 역할 (예: Role.CUSTOMER, Role.MOVER 등)
+};
+
+export const UserInfo = createParamDecorator(
+  (_: unknown, context: ExecutionContext) => {
+    const req = context.switchToHttp().getRequest();
+
+    if (!req || !req.user || !req.user.sub) {
+      throw new UnauthorizedException('사용자 정보를 찾을 수 없습니다!');
+    }
+
+    const userInfo: UserInfo = {
+      sub: req.user.sub, // 사용자 ID
+      role: req.user.role, // 사용자 역할
+    };
+
+    return userInfo;
+  },
+);


### PR DESCRIPTION
## 🧚 변경사항 설명

1. RBAC guard를 사용하여 mover만 프로필 생성 가능하도록 지정
2. UserInfo decorator를 사용하여 user의 id, role을 token의 payload에서 정보 일부분을 반환하여 사용하도록 함\
3. dto 설정 완료, custom validator 추가 (HasAtLeastOneTrue: 객체에서 최소 하나 이상 true로 선택되어 있는지 확인)
5. postman test 완료

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

리뷰 부탁드립니다.

## 🤙🏻 관련 이슈
#6 

## 📸 스크린샷

![Image](https://github.com/user-attachments/assets/88e6cf99-a84c-4e93-bd60-44496c764154)
