### PR TITLE
feat: 기사 프로필 상세 조회 기능 추가 및 본인 기사 프로필 조회 리팩토링

### DIFF
--- a/src/mover-profile/mover-profile.controller.ts
+++ b/src/mover-profile/mover-profile.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Body, Patch } from '@nestjs/common';
+import { Controller, Get, Post, Body, Patch, Param } from '@nestjs/common';
 import { MoverProfileService } from './mover-profile.service';
 import { CreateMoverProfileDto } from './dto/create-mover-profile.dto';
 import { UpdateMoverProfileDto } from './dto/update-mover-profile.dto';
@@ -44,8 +44,14 @@ export class MoverProfileController {
 
   @Get('me')
   @ApiGetMyMoverProfile()
-  findOne(@UserInfo() userInfo: UserInfo) {
-    return this.moverProfileService.findOne(userInfo.sub);
+  findMe(@UserInfo() userInfo: UserInfo) {
+    return this.moverProfileService.findMe(userInfo.sub);
+  }
+
+  @Get(':id')
+  @Public()
+  findOne(@Param('id') id: string) {
+    return this.moverProfileService.findOne(id);
   }
 
   @Patch('me')

--- a/src/mover-profile/mover-profile.module.ts
+++ b/src/mover-profile/mover-profile.module.ts
@@ -7,6 +7,7 @@ import { MoverProfileView } from './view/mover-profile.view';
 import { CommonModule } from 'src/common/common.module';
 import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
 import { EstimateRequest } from '@/estimate-request/entities/estimate-request.entity';
+import { Review } from '@/review/entities/review.entity';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { EstimateRequest } from '@/estimate-request/entities/estimate-request.en
       MoverProfileView,
       CustomerProfile,
       EstimateRequest,
+      Review,
     ]),
     CommonModule,
   ],

--- a/src/review/entities/review.entity.ts
+++ b/src/review/entities/review.entity.ts
@@ -19,6 +19,7 @@ export class Review extends BaseTable {
     type: 'uuid',
   })
   @OneToOne(() => EstimateOffer, (offer) => offer.review)
+  @JoinColumn({ name: 'estimateOfferId' }) // FK 컬럼 이름 지정
   estimateOffer: EstimateOffer; // 견적 제안 id
 
   @PrimaryColumn({
@@ -26,6 +27,7 @@ export class Review extends BaseTable {
     type: 'uuid',
   })
   @ManyToOne(() => CustomerProfile, (customer) => customer.reviews)
+  @JoinColumn({ name: 'customerId' }) // FK 컬럼 이름 지정
   customer: CustomerProfile; // 고객 id
 
   @Column()


### PR DESCRIPTION
## 🧚 변경사항 설명

1. 기사 프로필 상세 조회 기능 추가
2. @Get(':id')가 먼저 선언되면 /mover/me를 id = 'me'로 처리, findOne('me') 호출하므로
    @Get('me')를 먼저 선언하면 /mover/me가 findMe로 정확히 매핑, 인증 로직 적용
3. review 엔티티 수정 FK 누락된 부분 추가