### PR TITLE
Feat/견적 요청 생성 & 요청ID 에 대한 견적 목록 조회

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "seed": "ts-node -r tsconfig-paths/register src/seed/index.ts"
   },
   "dependencies": {
     "@nestjs/common": "^11.0.1",
@@ -32,6 +33,7 @@
     "bcrypt": "^6.0.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.2",
+    "dotenv": "^16.5.0",
     "joi": "^17.13.3",
     "lodash": "^4.17.21",
     "passport": "^0.7.0",
@@ -52,6 +54,7 @@
     "@swc/cli": "^0.6.0",
     "@swc/core": "^1.10.7",
     "@types/bcrypt": "^5.0.2",
+    "@types/dotenv": "^8.2.3",
     "@types/express": "^5.0.0",
     "@types/jest": "^29.5.14",
     "@types/lodash": "^4.17.17",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,10 +4,8 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
-import { ConfigModule, ConfigService } from '@nestjs/config';
-import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigModule } from '@nestjs/config';
 import * as Joi from 'joi';
-import { envVariableKeys } from './common/const/env.const';
 import { UserModule } from './user/user.module';
 import { NotificationModule } from './notification/notification.module';
 import { MoverProfileModule } from './mover-profile/mover-profile.module';
@@ -16,15 +14,6 @@ import { LikeModule } from './like/like.module';
 import { EstimateRequestModule } from './estimate-request/estimate-request.module';
 import { EstimateOfferModule } from './estimate-offer/estimate-offer.module';
 import { ReviewModule } from './review/review.module';
-import { User } from './user/entities/user.entity';
-import { Notification } from './notification/entities/notification.entity';
-import { MoverProfile } from './mover-profile/entities/mover-profile.entity';
-import { MoverProfileView } from './mover-profile/view/mover-profile.view';
-import { CustomerProfile } from './customer-profile/entities/customer-profile.entity';
-import { Like } from './like/entities/like.entity';
-import { EstimateRequest } from './estimate-request/entities/estimate-request.entity';
-import { Review } from './review/entities/review.entity';
-import { EstimateOffer } from './estimate-offer/entities/estimate-offer.entity';
 import { AuthModule } from './auth/auth.module';
 import { AuthGuard } from './auth/guard/auth.guard';
 import { BearerTokenMiddleware } from './auth/middleware/bearer-token.middleware';
@@ -32,48 +21,26 @@ import { ForbiddenExceptionFilter } from './common/filter/forbidden.filter';
 import { RbacGuard } from './auth/guard/rbac.guard';
 import { QueryFailedExceptionFilter } from './common/filter/query-failed.filter';
 import { ResponseTimeInterceptor } from './common/interceptor/response-time.interceptor';
-
+import { DatabaseModule } from './database/database.module';
+import { databaseValidationSchema } from './database/database.config';
+const appValidationSchema = Joi.object({
+  ENV: Joi.string().valid('dev', 'prod').required(),
+  HASH_ROUNDS: Joi.number().required(),
+  ACCESS_TOKEN_SECRET: Joi.string().required(),
+  REFRESH_TOKEN_SECRET: Joi.string().required(),
+}).concat(databaseValidationSchema);
 @Module({
   imports: [
     ConfigModule.forRoot({
       isGlobal: true,
-      validationSchema: Joi.object({
-        ENV: Joi.string().valid('dev', 'prod').required(),
-        DB_TYPE: Joi.string().valid('postgres').required(),
-        DB_HOST: Joi.string().required(),
-        DB_PORT: Joi.number().required(),
-        DB_USERNAME: Joi.string().required(),
-        DB_PASSWORD: Joi.string().required(),
-        DB_DATABASE: Joi.string().required(),
-        HASH_ROUNDS: Joi.number().required(),
-        ACCESS_TOKEN_SECRET: Joi.string().required(),
-        REFRESH_TOKEN_SECRET: Joi.string().required(),
-      }),
+      validationSchema: appValidationSchema,
     }),
-    TypeOrmModule.forRootAsync({
-      useFactory: (configService: ConfigService) => ({
-        type: configService.get<string>(envVariableKeys.dbType) as 'postgres',
-        host: configService.get<string>(envVariableKeys.dbHost),
-        port: configService.get<number>(envVariableKeys.dbPort),
-        username: configService.get<string>(envVariableKeys.dbUsername),
-        password: configService.get<string>(envVariableKeys.dbPassword),
-        database: configService.get<string>(envVariableKeys.dbDatabase),
-        entities: [
-          User,
-          Notification,
-          MoverProfile,
-          MoverProfileView,
-          CustomerProfile,
-          Like,
-          EstimateRequest,
-          EstimateOffer,
-          Review,
-        ], // 엔티티 등록
-        synchronize: true,
-        ssl: { rejectUnauthorized: false },
-      }),
-      inject: [ConfigService],
-    }),
+
+    // 핵심 모듈
+    DatabaseModule,
+    AuthModule,
+
+    // 비지니스 모듈
     UserModule,
     NotificationModule,
     MoverProfileModule,
@@ -82,7 +49,6 @@ import { ResponseTimeInterceptor } from './common/interceptor/response-time.inte
     EstimateRequestModule,
     EstimateOfferModule,
     ReviewModule,
-    AuthModule,
   ],
   providers: [
     {

--- a/src/common/interceptor/response-time.interceptor.ts
+++ b/src/common/interceptor/response-time.interceptor.ts
@@ -23,11 +23,11 @@ export class ResponseTimeInterceptor implements NestInterceptor {
 
         let logMessage = `[${request.method} ${request.path}] ${diff}ms`;
 
-        if (diff > 1000) {
+        if (diff > 10000) {
           logMessage = '!!!TIME OUT!!!' + logMessage;
           console.log(logMessage);
           throw new InternalServerErrorException(
-            '응답 시간이 1초를 초과하였습니다!',
+            '응답 시간이 10초를 초과하였습니다!',
           );
         }
 

--- a/src/database/database.config.ts
+++ b/src/database/database.config.ts
@@ -1,0 +1,10 @@
+import * as Joi from 'joi';
+
+export const databaseValidationSchema = Joi.object({
+  DB_TYPE: Joi.string().valid('postgres').required(),
+  DB_HOST: Joi.string().required(),
+  DB_PORT: Joi.number().required(),
+  DB_USERNAME: Joi.string().required(),
+  DB_PASSWORD: Joi.string().required(),
+  DB_DATABASE: Joi.string().required(),
+});

--- a/src/database/database.entities.ts
+++ b/src/database/database.entities.ts
@@ -1,0 +1,21 @@
+import { User } from '@/user/entities/user.entity';
+import { Notification } from '@/notification/entities/notification.entity';
+import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
+import { MoverProfileView } from '@/mover-profile/view/mover-profile.view';
+import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
+import { Like } from '@/like/entities/like.entity';
+import { EstimateRequest } from '@/estimate-request/entities/estimate-request.entity';
+import { EstimateOffer } from '@/estimate-offer/entities/estimate-offer.entity';
+import { Review } from '@/review/entities/review.entity';
+
+export const ENTITIES = [
+  User,
+  Notification,
+  MoverProfile,
+  MoverProfileView,
+  CustomerProfile,
+  Like,
+  EstimateRequest,
+  EstimateOffer,
+  Review,
+];

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { ConfigService } from '@nestjs/config';
+import { envVariableKeys } from '@/common/const/env.const';
+import { ENTITIES } from './database.entities';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRootAsync({
+      useFactory: (configService: ConfigService) => ({
+        type: configService.get<string>(envVariableKeys.dbType) as 'postgres',
+        host: configService.get<string>(envVariableKeys.dbHost),
+        port: configService.get<number>(envVariableKeys.dbPort),
+        username: configService.get<string>(envVariableKeys.dbUsername),
+        password: configService.get<string>(envVariableKeys.dbPassword),
+        database: configService.get<string>(envVariableKeys.dbDatabase),
+        entities: ENTITIES,
+        synchronize: true,
+        ssl: { rejectUnauthorized: false },
+      }),
+      inject: [ConfigService],
+    }),
+  ],
+})
+export class DatabaseModule {}

--- a/src/estimate-offer/docs/swagger.ts
+++ b/src/estimate-offer/docs/swagger.ts
@@ -1,0 +1,40 @@
+import { applyDecorators } from '@nestjs/common';
+import {
+  ApiBearerAuth,
+  ApiOperation,
+  ApiQuery,
+  ApiResponse,
+} from '@nestjs/swagger';
+import { EstimateOfferResponseDto } from '../dto/estimate-offer-response.dto';
+
+export function ApiGetEstimateOffers() {
+  return applyDecorators(
+    // ApiBearerAuth('access-token'),
+    ApiOperation({
+      summary: '견적 요청에 대한 오퍼 목록 조회',
+      description:
+        '특정 견적 요청 ID에 해당하는 모든 이사 제안 목록을 조회합니다. 로그인한 고객 본인의 요청에 한해서만 조회 가능합니다.',
+    }),
+    ApiQuery({
+      name: 'id',
+      required: true,
+      description: '견적 요청 ID (UUID)',
+      example: '1c340ecf-e7f8-4431-bad2-dc19ea9ff3e7',
+      type: String,
+    }),
+    ApiResponse({
+      status: 200,
+      description: '견적 제안 목록 조회 성공',
+      type: EstimateOfferResponseDto,
+      isArray: true,
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청. 견적 요청 ID가 유효하지 않음',
+    }),
+    ApiResponse({
+      status: 403,
+      description: '권한 없음. 본인의 요청이 아닐 경우',
+    }),
+  );
+}

--- a/src/estimate-offer/docs/swagger.ts
+++ b/src/estimate-offer/docs/swagger.ts
@@ -1,10 +1,5 @@
 import { applyDecorators } from '@nestjs/common';
-import {
-  ApiBearerAuth,
-  ApiOperation,
-  ApiQuery,
-  ApiResponse,
-} from '@nestjs/swagger';
+import { ApiOperation, ApiParam, ApiResponse } from '@nestjs/swagger';
 import { EstimateOfferResponseDto } from '../dto/estimate-offer-response.dto';
 
 export function ApiGetEstimateOffers() {
@@ -15,8 +10,8 @@ export function ApiGetEstimateOffers() {
       description:
         '특정 견적 요청 ID에 해당하는 모든 이사 제안 목록을 조회합니다. 로그인한 고객 본인의 요청에 한해서만 조회 가능합니다.',
     }),
-    ApiQuery({
-      name: 'id',
+    ApiParam({
+      name: 'requestId',
       required: true,
       description: '견적 요청 ID (UUID)',
       example: '1c340ecf-e7f8-4431-bad2-dc19ea9ff3e7',

--- a/src/estimate-offer/dto/estimate-offer-response.dto.ts
+++ b/src/estimate-offer/dto/estimate-offer-response.dto.ts
@@ -1,0 +1,28 @@
+import { ServiceRegion, ServiceTypeMap } from '@/common/const/service.const';
+import { OfferStatus } from '../entities/estimate-offer.entity';
+
+export class EstimateOfferResponseDto {
+  estimateRequestId: string;
+  moverId: string;
+  price: number;
+  comment?: string;
+  status: OfferStatus;
+  isTargeted: boolean;
+  isConfirmed: boolean;
+  confirmedAt: Date;
+
+  // mover 프로필 응답에 포함
+  mover: {
+    nickname: string;
+    imageUrl?: string;
+    career: number;
+    serviceType: ServiceTypeMap;
+    serviceRegion: ServiceRegion;
+    intro: string;
+    rating: number;
+    reviewCount: number;
+    likeCount: number;
+    isLiked: boolean;
+    experience: number;
+  };
+}

--- a/src/estimate-offer/estimate-offer.controller.ts
+++ b/src/estimate-offer/estimate-offer.controller.ts
@@ -6,15 +6,27 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
 } from '@nestjs/common';
 import { EstimateOfferService } from './estimate-offer.service';
 import { CreateEstimateOfferDto } from './dto/create-estimate-offer.dto';
 import { UpdateEstimateOfferDto } from './dto/update-estimate-offer.dto';
+import { UserInfo } from '@/user/decorator/user-info.decorator';
 
 @Controller('estimate-offer')
 export class EstimateOfferController {
   constructor(private readonly estimateOfferService: EstimateOfferService) {}
 
+  @Get()
+  async getOffersByEstimateRequestId(
+    @Query('id') estimateRequestId: string,
+    @UserInfo() userInfo: UserInfo, // 현재 로그인한 유저 정보
+  ) {
+    return this.estimateOfferService.findByEstimateRequestId(
+      estimateRequestId,
+      userInfo.sub,
+    );
+  }
   @Post()
   create(@Body() createEstimateOfferDto: CreateEstimateOfferDto) {
     return this.estimateOfferService.create(createEstimateOfferDto);
@@ -23,11 +35,6 @@ export class EstimateOfferController {
   @Get()
   findAll() {
     return this.estimateOfferService.findAll();
-  }
-
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.estimateOfferService.findOne(+id);
   }
 
   @Patch(':id')

--- a/src/estimate-offer/estimate-offer.controller.ts
+++ b/src/estimate-offer/estimate-offer.controller.ts
@@ -13,20 +13,25 @@ import { CreateEstimateOfferDto } from './dto/create-estimate-offer.dto';
 import { UpdateEstimateOfferDto } from './dto/update-estimate-offer.dto';
 import { UserInfo } from '@/user/decorator/user-info.decorator';
 import { ApiGetEstimateOffers } from './docs/swagger';
-import { ApiBearerAuth } from '@nestjs/swagger';
+import { ApiBearerAuth, ApiParam } from '@nestjs/swagger';
 @Controller('estimate-offer')
 export class EstimateOfferController {
   constructor(private readonly estimateOfferService: EstimateOfferService) {}
 
-  @Get()
+  @Get(':requestId')
   @ApiBearerAuth()
+  @ApiParam({
+    name: 'requestId',
+    description: '견적 요청 ID (UUID)',
+    type: String,
+  })
   @ApiGetEstimateOffers()
   async getOffersByEstimateRequestId(
-    @Query('id') estimateRequestId: string,
-    @UserInfo() userInfo: UserInfo, // 현재 로그인한 유저 정보
+    @Param('requestId') requestId: string,
+    @UserInfo() userInfo: UserInfo,
   ) {
     return this.estimateOfferService.findByEstimateRequestId(
-      estimateRequestId,
+      requestId,
       userInfo.sub,
     );
   }

--- a/src/estimate-offer/estimate-offer.controller.ts
+++ b/src/estimate-offer/estimate-offer.controller.ts
@@ -12,12 +12,15 @@ import { EstimateOfferService } from './estimate-offer.service';
 import { CreateEstimateOfferDto } from './dto/create-estimate-offer.dto';
 import { UpdateEstimateOfferDto } from './dto/update-estimate-offer.dto';
 import { UserInfo } from '@/user/decorator/user-info.decorator';
-
+import { ApiGetEstimateOffers } from './docs/swagger';
+import { ApiBearerAuth } from '@nestjs/swagger';
 @Controller('estimate-offer')
 export class EstimateOfferController {
   constructor(private readonly estimateOfferService: EstimateOfferService) {}
 
   @Get()
+  @ApiBearerAuth()
+  @ApiGetEstimateOffers()
   async getOffersByEstimateRequestId(
     @Query('id') estimateRequestId: string,
     @UserInfo() userInfo: UserInfo, // 현재 로그인한 유저 정보
@@ -30,11 +33,6 @@ export class EstimateOfferController {
   @Post()
   create(@Body() createEstimateOfferDto: CreateEstimateOfferDto) {
     return this.estimateOfferService.create(createEstimateOfferDto);
-  }
-
-  @Get()
-  findAll() {
-    return this.estimateOfferService.findAll();
   }
 
   @Patch(':id')

--- a/src/estimate-offer/estimate-offer.module.ts
+++ b/src/estimate-offer/estimate-offer.module.ts
@@ -1,9 +1,14 @@
 import { Module } from '@nestjs/common';
 import { EstimateOfferService } from './estimate-offer.service';
 import { EstimateOfferController } from './estimate-offer.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { EstimateOffer } from './entities/estimate-offer.entity';
+import { EstimateRequest } from '@/estimate-request/entities/estimate-request.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([EstimateOffer, EstimateRequest])],
   controllers: [EstimateOfferController],
   providers: [EstimateOfferService],
+  exports: [EstimateOfferService],
 })
 export class EstimateOfferModule {}

--- a/src/estimate-offer/estimate-offer.service.ts
+++ b/src/estimate-offer/estimate-offer.service.ts
@@ -1,9 +1,99 @@
-import { Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+} from '@nestjs/common';
 import { CreateEstimateOfferDto } from './dto/create-estimate-offer.dto';
 import { UpdateEstimateOfferDto } from './dto/update-estimate-offer.dto';
+import { InjectRepository } from '@nestjs/typeorm';
+import { EstimateOffer } from './entities/estimate-offer.entity';
+import { Repository } from 'typeorm';
+import { EstimateOfferResponseDto } from './dto/estimate-offer-response.dto';
+import { ServiceRegion } from '@/common/const/service.const';
+import { EstimateRequest } from '@/estimate-request/entities/estimate-request.entity';
 
 @Injectable()
 export class EstimateOfferService {
+  constructor(
+    @InjectRepository(EstimateOffer)
+    private readonly offerRepository: Repository<EstimateOffer>,
+    @InjectRepository(EstimateRequest)
+    private readonly requestRepository: Repository<EstimateRequest>,
+  ) {}
+  /**
+   * 견적 요청 ID로 견적 목록 조회
+   * @param estimateRequestId 견적 요청 ID
+   * @param userId 현재 로그인한 유저 ID
+   * @returns 해당 요청 ID에 대한 견적 제안 목록
+   */
+  async findByEstimateRequestId(
+    estimateRequestId: string,
+    userId?: string,
+  ): Promise<EstimateOfferResponseDto[]> {
+    // if (!estimateRequestId) return []; // estimateRequestId가 없으면 빈 배열 반환
+    //개발중 예외처리 TODO: 추후에 수정
+    if (!estimateRequestId) {
+      throw new BadRequestException(
+        'estimateRequestId 쿼리 파라미터가 필요합니다.',
+      );
+    } // 견적 요청 조회 및 본인 여부 확인
+    const request = await this.requestRepository.findOne({
+      where: { id: estimateRequestId },
+      relations: ['customer', 'customer.user'],
+    });
+
+    if (!request) {
+      throw new BadRequestException('존재하지 않는 견적 요청입니다.');
+    }
+
+    if (request.customer.user.id !== userId) {
+      throw new ForbiddenException();
+    }
+    const offers = await this.offerRepository.find({
+      where: { estimateRequestId },
+      relations: ['mover', 'mover.likedCustomers', 'mover.reviews'],
+      order: { createdAt: 'DESC' },
+    });
+
+    return offers.map((offer) => {
+      const mover = offer.mover;
+      const reviews = mover.reviews || [];
+
+      const rating =
+        reviews.length > 0
+          ? reviews.reduce((sum, r) => sum + r.rating, 0) / reviews.length
+          : 0;
+
+      const isLiked = userId
+        ? mover.likedCustomers?.some((like) => like.customer.id === userId)
+        : false;
+
+      return {
+        estimateRequestId: offer.estimateRequestId,
+        moverId: offer.moverId,
+        price: offer.price,
+        comment: offer.comment,
+        status: offer.status,
+        isTargeted: offer.isTargeted,
+        isConfirmed: offer.isConfirmed,
+        confirmedAt: offer.confirmedAt,
+        mover: {
+          nickname: mover.nickname,
+          imageUrl: mover.imageUrl,
+          career: mover.experience,
+          serviceType: mover.serviceType,
+          serviceRegion: mover.serviceRegion as any as ServiceRegion,
+          intro: mover.intro,
+          rating: Number.isFinite(rating) ? Number(rating.toFixed(1)) : 0,
+          reviewCount: reviews.length,
+          likeCount: mover.likedCustomers?.length || 0,
+          isLiked,
+          experience: mover.experience,
+        },
+      };
+    });
+  }
+
   create(createEstimateOfferDto: CreateEstimateOfferDto) {
     return 'This action adds a new estimateOffer';
   }

--- a/src/estimate-offer/estimate-offer.service.ts
+++ b/src/estimate-offer/estimate-offer.service.ts
@@ -34,9 +34,10 @@ export class EstimateOfferService {
     //개발중 예외처리 TODO: 추후에 수정
     if (!estimateRequestId) {
       throw new BadRequestException(
-        'estimateRequestId 쿼리 파라미터가 필요합니다.',
+        '견적 요청 ID 파라미터(requestId)가 필요합니다.',
       );
-    } // 견적 요청 조회 및 본인 여부 확인
+    }
+    // 견적 요청 조회 및 본인 여부 확인
     const request = await this.requestRepository.findOne({
       where: { id: estimateRequestId },
       relations: ['customer', 'customer.user'],

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -1,0 +1,60 @@
+import {
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiBody,
+} from '@nestjs/swagger';
+import { applyDecorators } from '@nestjs/common';
+
+import { CreateEstimateRequestDto } from '@/estimate-request/dto/create-estimate-request.dto';
+import { EstimateRequestResponseDto } from '@/estimate-request/dto/estimate-request-response.dto';
+import {
+  CODE_201_CREATED,
+  CODE_400_BAD_REQUEST,
+  CODE_401_RESPONSES,
+} from '@/common/docs/response.swagger';
+
+export function ApiCreateEstimateRequest() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '견적 요청 생성',
+      description: '고객이 새로운 견적 요청을 생성합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiBody({
+      type: CreateEstimateRequestDto,
+      examples: {
+        basic: {
+          summary: '기본 예시',
+          value: {
+            moveType: 'HOME',
+            moveDate: '2025-07-15',
+            fromAddress: {
+              sido: '경기',
+              sidoEnglish: 'Gyeonggi',
+              sigungu: '성남시 분당구',
+              roadAddress: '불정로 6',
+              fullAddress: '경기 성남시 분당구 불정로 6',
+            },
+            toAddress: {
+              sido: '서울',
+              sidoEnglish: 'Seoul',
+              sigungu: '강남구',
+              roadAddress: '테헤란로 212',
+              fullAddress: '서울 강남구 테헤란로 212',
+            },
+            targetMoverIds: ['a1b2c3d4-e5f6-7890-1234-56789abcdeff'],
+          },
+        },
+      },
+    }),
+    ApiResponse(
+      CODE_201_CREATED({
+        description: '견적 요청 생성 성공',
+        schema: { example: EstimateRequestResponseDto },
+      }),
+    ),
+    ApiResponse(CODE_400_BAD_REQUEST([])),
+    ApiResponse(CODE_401_RESPONSES),
+  );
+}

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -1,60 +1,50 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  Delete,
+} from '@nestjs/common';
+import { EstimateRequestService } from './estimate-request.service';
 import { CreateEstimateRequestDto } from './dto/create-estimate-request.dto';
 
-import { InjectRepository } from '@nestjs/typeorm';
-import { EstimateRequest } from './entities/estimate-request.entity';
-import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
-import { Repository } from 'typeorm';
+import { UpdateEstimateRequestDto } from './dto/update-estimate-request.dto';
+
 import { UserInfo } from '@/user/decorator/user-info.decorator';
+import { ApiBearerAuth } from '@nestjs/swagger';
+import { RBAC } from '@/auth/decorator/rbac.decorator';
+import { Role } from '@/user/entities/user.entity';
+import { ApiCreateEstimateRequest } from './docs/swagger';
 
-@Injectable()
-export class EstimateRequestService {
+@ApiBearerAuth()
+@Controller('estimate-request')
+@RBAC(Role.CUSTOMER)
+export class EstimateRequestController {
   constructor(
-    @InjectRepository(EstimateRequest)
-    private readonly estimateRequestRepository: Repository<EstimateRequest>,
-    @InjectRepository(CustomerProfile)
-    private readonly customerProfileRepository: Repository<CustomerProfile>,
+    private readonly estimateRequestService: EstimateRequestService,
   ) {}
-  /**
-   * 견적 요청 생성
-   * @param dto - 견적 요청 정보
-   * @param user - 현재 로그인한 유저 정보
-   * @returns 생성된 견적 요청 정보
-   * @throws NotFoundException - 고객 프로필을 찾을 수 없는 경우
-   */
-  async create(dto: CreateEstimateRequestDto, user: UserInfo) {
-    // 1. 로그인한 유저의 CustomerProfile 가져오기
-    const customer = await this.customerProfileRepository.findOne({
-      where: { user: { id: user.sub } },
-      relations: ['user'],
-    });
 
-    if (!customer) {
-      throw new NotFoundException('고객 프로필을 찾을 수 없습니다.');
-    }
-    //TODO: 현재 유저가 진행 중인 견적 요청이 있는지 확인하는 로직 추가 필요
-    //이미 PENDING, CONFIRMED, CANCELED 상태의 견적 요청을 가지고 있다면, 새로운 요청 생성 불가
-    //COMPLETED 또는 EXPIRED 상태인 경우에만 새로운 요청 생성 가능
+  @Post()
+  @ApiCreateEstimateRequest()
+  async create(
+    @Body() dto: CreateEstimateRequestDto,
+    @UserInfo() user: UserInfo, // UserInfo 데코레이터를 통해 현재 로그인한 유저 정보 가져오기
+  ) {
+    return this.estimateRequestService.create(dto, user);
+  }
 
-    // 2. EstimateRequest 인스턴스 생성
-    const estimate = this.estimateRequestRepository.create({
-      moveType: dto.moveType,
-      moveDate: new Date(dto.moveDate),
-      fromAddress: dto.fromAddress,
-      toAddress: dto.toAddress,
-      customer,
-    });
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body() updateEstimateRequestDto: UpdateEstimateRequestDto,
+  ) {
+    return this.estimateRequestService.update(+id, updateEstimateRequestDto);
+  }
 
-    // 3. 저장
-    const saved = await this.estimateRequestRepository.save(estimate);
-    const withRelations = await this.estimateRequestRepository.findOne({
-      where: { id: saved.id },
-      relations: ['customer', 'customer.user'],
-    });
-
-    return {
-      message: '견적 요청이 성공적으로 생성되었습니다.',
-      id: saved.id,
-    };
+  @Delete(':id')
+  remove(@Param('id') id: string) {
+    return this.estimateRequestService.remove(+id);
   }
 }

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -1,53 +1,60 @@
-import {
-  Controller,
-  Get,
-  Post,
-  Body,
-  Patch,
-  Param,
-  Delete,
-} from '@nestjs/common';
-import { EstimateRequestService } from './estimate-request.service';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateEstimateRequestDto } from './dto/create-estimate-request.dto';
 
-import { UpdateEstimateRequestDto } from './dto/update-estimate-request.dto';
-
+import { InjectRepository } from '@nestjs/typeorm';
+import { EstimateRequest } from './entities/estimate-request.entity';
+import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
+import { Repository } from 'typeorm';
 import { UserInfo } from '@/user/decorator/user-info.decorator';
 
-@Controller('estimate-request')
-export class EstimateRequestController {
+@Injectable()
+export class EstimateRequestService {
   constructor(
-    private readonly estimateRequestService: EstimateRequestService,
+    @InjectRepository(EstimateRequest)
+    private readonly estimateRequestRepository: Repository<EstimateRequest>,
+    @InjectRepository(CustomerProfile)
+    private readonly customerProfileRepository: Repository<CustomerProfile>,
   ) {}
+  /**
+   * 견적 요청 생성
+   * @param dto - 견적 요청 정보
+   * @param user - 현재 로그인한 유저 정보
+   * @returns 생성된 견적 요청 정보
+   * @throws NotFoundException - 고객 프로필을 찾을 수 없는 경우
+   */
+  async create(dto: CreateEstimateRequestDto, user: UserInfo) {
+    // 1. 로그인한 유저의 CustomerProfile 가져오기
+    const customer = await this.customerProfileRepository.findOne({
+      where: { user: { id: user.sub } },
+      relations: ['user'],
+    });
 
-  @Post()
-  async create(
-    @Body() dto: CreateEstimateRequestDto,
-    @UserInfo() user: UserInfo, // UserInfo 데코레이터를 통해 현재 로그인한 유저 정보 가져오기
-  ) {
-    return this.estimateRequestService.create(dto, user);
-  }
+    if (!customer) {
+      throw new NotFoundException('고객 프로필을 찾을 수 없습니다.');
+    }
+    //TODO: 현재 유저가 진행 중인 견적 요청이 있는지 확인하는 로직 추가 필요
+    //이미 PENDING, CONFIRMED, CANCELED 상태의 견적 요청을 가지고 있다면, 새로운 요청 생성 불가
+    //COMPLETED 또는 EXPIRED 상태인 경우에만 새로운 요청 생성 가능
 
-  @Get()
-  findAll() {
-    return this.estimateRequestService.findAll();
-  }
+    // 2. EstimateRequest 인스턴스 생성
+    const estimate = this.estimateRequestRepository.create({
+      moveType: dto.moveType,
+      moveDate: new Date(dto.moveDate),
+      fromAddress: dto.fromAddress,
+      toAddress: dto.toAddress,
+      customer,
+    });
 
-  @Get(':id')
-  findOne(@Param('id') id: string) {
-    return this.estimateRequestService.findOne(+id);
-  }
+    // 3. 저장
+    const saved = await this.estimateRequestRepository.save(estimate);
+    const withRelations = await this.estimateRequestRepository.findOne({
+      where: { id: saved.id },
+      relations: ['customer', 'customer.user'],
+    });
 
-  @Patch(':id')
-  update(
-    @Param('id') id: string,
-    @Body() updateEstimateRequestDto: UpdateEstimateRequestDto,
-  ) {
-    return this.estimateRequestService.update(+id, updateEstimateRequestDto);
-  }
-
-  @Delete(':id')
-  remove(@Param('id') id: string) {
-    return this.estimateRequestService.remove(+id);
+    return {
+      message: '견적 요청이 성공적으로 생성되었습니다.',
+      id: saved.id,
+    };
   }
 }

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -55,19 +55,6 @@ export class EstimateRequestService {
     });
   }
 
-  async findOneById(id: string) {
-    const result = await this.estimateRequestRepository.findOne({
-      where: { id },
-      relations: ['customer', 'customer.user'],
-    });
-
-    if (!result) throw new NotFoundException('견적 요청을 찾을 수 없습니다.');
-
-    return plainToInstance(EstimateRequestResponseDto, result, {
-      excludeExtraneousValues: true,
-    });
-  }
-
   findAll() {
     return `This action returns all estimateRequest`;
   }

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -2,10 +2,7 @@ import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreateEstimateRequestDto } from './dto/create-estimate-request.dto';
 import { UpdateEstimateRequestDto } from './dto/update-estimate-request.dto';
 import { InjectRepository } from '@nestjs/typeorm';
-import {
-  EstimateRequest,
-  RequestStatus,
-} from './entities/estimate-request.entity';
+import { EstimateRequest } from './entities/estimate-request.entity';
 import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
 import { Repository } from 'typeorm';
 import { UserInfo } from '@/user/decorator/user-info.decorator';

--- a/src/seed/estimate-offer.seed.ts
+++ b/src/seed/estimate-offer.seed.ts
@@ -1,0 +1,55 @@
+import { DataSource } from 'typeorm';
+import {
+  EstimateOffer,
+  OfferStatus,
+} from 'src/estimate-offer/entities/estimate-offer.entity';
+import { EstimateRequest } from 'src/estimate-request/entities/estimate-request.entity';
+import { MoverProfile } from 'src/mover-profile/entities/mover-profile.entity';
+
+const MOVERS = [
+  { id: 'e5169339-00fb-4da3-a6b3-2fb218f2ee17', price: 150000 },
+  { id: 'b17632c0-1c4c-4bd5-b739-887d2e6d2894', price: 160000 },
+  { id: '9e2bf623-15ce-4648-9378-26cb73239625', price: 145000 },
+  { id: '89127260-7cc3-4706-b457-adb90a45cddf', price: 155000 },
+  { id: '690f46ff-1c28-431d-8767-4fdc400b3cc9', price: 170000 },
+];
+
+export const seedEstimateOffers = async (dataSource: DataSource) => {
+  const estimateRequestRepo = dataSource.getRepository(EstimateRequest);
+  const moverRepo = dataSource.getRepository(MoverProfile);
+  const offerRepo = dataSource.getRepository(EstimateOffer);
+
+  const request = await estimateRequestRepo.findOneByOrFail({
+    id: '76ae6e9e-ea6f-4434-82c6-99a76c96db73', // 예시로 사용할 견적 요청 ID
+  });
+
+  const now = new Date();
+  let successCount = 0;
+
+  for (const { id: moverId, price } of MOVERS) {
+    try {
+      const mover = await moverRepo.findOneOrFail({ where: { id: moverId } });
+
+      const offer = offerRepo.create({
+        estimateRequestId: request.id,
+        moverId: mover.id,
+        estimateRequest: request,
+        mover: mover,
+        price: price,
+        comment: `${mover.nickname}의 견적 제안입니다.`,
+        status: OfferStatus.SUBMITTED,
+        isTargeted: false,
+        isConfirmed: false,
+        confirmedAt: new Date(),
+      });
+
+      await offerRepo.save(offer);
+      console.log(`✅ 견적 제안 생성됨: ${mover.nickname} → ${request.id}`);
+      successCount++;
+    } catch (err) {
+      console.error(`❌ ${moverId} 처리 중 오류:`, err.message);
+    }
+  }
+
+  console.log(`🎉 총 ${successCount}건의 estimate-offer 생성 완료`);
+};

--- a/src/seed/index.ts
+++ b/src/seed/index.ts
@@ -1,0 +1,39 @@
+// src/seed/index.ts
+
+import { config } from 'dotenv';
+import { DataSource } from 'typeorm';
+import { seedEstimateOffers } from './estimate-offer.seed';
+import { ENTITIES } from '@/database/database.entities';
+
+config();
+
+const dataSource = new DataSource({
+  type: 'postgres',
+  host: process.env.DB_HOST,
+  port: Number(process.env.DB_PORT),
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  entities: ENTITIES,
+  synchronize: false,
+  ssl: { rejectUnauthorized: false },
+});
+
+const runSeeds = async () => {
+  try {
+    console.log('🟡 DB 연결 중...');
+    await dataSource.initialize();
+
+    console.log('📦 견적 제안 시드 실행 중...');
+    await seedEstimateOffers(dataSource);
+
+    console.log('✅ 시드 완료');
+  } catch (err) {
+    console.error('❌ 시드 실패:', err);
+    process.exit(1);
+  } finally {
+    await dataSource.destroy();
+  }
+};
+
+runSeeds();


### PR DESCRIPTION
## 🧚 변경사항 설명
- 각각 customer가 견적 요청(estimate-request)을 생성하고, 그 요청에 대해 mover들이 보낸 (estimate-offer)견적서를 조회하는 API 입니다.
- estimate-request 생성 (POST /api/estimate-request)
- estimateRequestId에 대한 estimate-offer 목록 조회 (GET /api/estimate-offer/{requestId})
- 쿼리에서 파라미터 방식으로 url 수정
## 🧑🏻‍🏫 To-do

- 견적 요청 생성 POST 요청시 현재 유저가 진행 중인 견적 요청이 있는지 확인하는 로직 추가
   - 이미 PENDING, CONFIRMED, CANCELED 상태의 견적 요청을 가지고 있다면, 새로운 요청 생성 불가하고, COMPLETED 또는 EXPIRE 상태인 경우에만 새로운 요청 생성 가능하도록
- /:moverId 붙여서 상세 조회 API 구현

## 🎤 공유 사항

- esitmate-offer 생성 API 가 아직 만들어져있지 않아서 estimateRequestId를 임의로 주고 그에 따른 estimate-offer를 생성하는 seed 데이터 생성 파일 추가했습니다.  test 해보실 분들은 다음 노션 페이지의 test flow 참고해주세요.
- https://www.notion.so/EstimateRequestId-EstimateOffer-test-flow-209d9fa672ba80d2a84def1da6c1a8be?source=copy_link

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #31

## 📸 스크린샷

### 견적 요청 생성
![image](https://github.com/user-attachments/assets/d86c4556-affb-4efa-82f1-c59451e8d6b2)

- 성공시
![image](https://github.com/user-attachments/assets/e558a7ce-749f-4ee8-98fa-ec25d73e6eea)

- mover 일경우 생성 불가 (rbac 적용됨)
![image](https://github.com/user-attachments/assets/f6148faf-a175-45e1-b10d-c13a67239a2c)

### requestId에 대한 request-offer 목록 조회
![image](https://github.com/user-attachments/assets/4c66fb29-fdf9-495b-99b7-465d9fc7b919)

- 성공시
![image](https://github.com/user-attachments/assets/3e8bf77c-fa53-4323-b818-bb059f29dd52)

- userId 다를 경우
![image](https://github.com/user-attachments/assets/da277e74-6ebe-418a-9425-a764d42fd09d)

