### PR TITLE
Refactor/auth swagger&user provider default

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       class-validator:
         specifier: ^0.14.2
         version: 0.14.2
+      dotenv:
+        specifier: ^16.5.0
+        version: 16.5.0
       joi:
         specifier: ^17.13.3
         version: 17.13.3
@@ -108,6 +111,9 @@ importers:
       '@types/bcrypt':
         specifier: ^5.0.2
         version: 5.0.2
+      '@types/dotenv':
+        specifier: ^8.2.3
+        version: 8.2.3
       '@types/express':
         specifier: ^5.0.0
         version: 5.0.2
@@ -1475,6 +1481,10 @@ packages:
   '@types/cookiejar@2.1.5':
     resolution: {integrity: sha512-he+DHOWReW0nghN24E1WUqM0efK4kI9oTqDm6XmK8ZPe2djZ90BSNdGnIyCLzCPw7/pogPlGbzI2wHGGmi4O/Q==}
 
+  '@types/dotenv@8.2.3':
+    resolution: {integrity: sha512-g2FXjlDX/cYuc5CiQvyU/6kkbP1JtmGzh0obW50zD7OKeILVL0NSpPWLXVfqoAGQjom2/SLLx9zHq0KXvD6mbw==}
+    deprecated: This is a stub types definition. dotenv provides its own type definitions, so you do not need this installed.
+
   '@types/eslint-scope@3.7.7':
     resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
 
@@ -2200,6 +2210,10 @@ packages:
 
   dotenv@16.4.7:
     resolution: {integrity: sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==}
+    engines: {node: '>=12'}
+
+  dotenv@16.5.0:
+    resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -6061,6 +6075,10 @@ snapshots:
 
   '@types/cookiejar@2.1.5': {}
 
+  '@types/dotenv@8.2.3':
+    dependencies:
+      dotenv: 16.5.0
+
   '@types/eslint-scope@3.7.7':
     dependencies:
       '@types/eslint': 9.6.1
@@ -6879,9 +6897,11 @@ snapshots:
 
   dotenv-expand@12.0.1:
     dependencies:
-      dotenv: 16.4.7
+      dotenv: 16.5.0
 
   dotenv@16.4.7: {}
+
+  dotenv@16.5.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -8857,7 +8877,7 @@ snapshots:
       dayjs: 1.11.13
       debug: 4.4.1
       dedent: 1.6.0
-      dotenv: 16.4.7
+      dotenv: 16.5.0
       glob: 10.4.5
       reflect-metadata: 0.2.2
       sha.js: 2.4.11

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -53,7 +53,7 @@ export class AuthController {
   /*로컬 로그인 서비스*/
   @Public()
   @UseGuards(LocalAuthGuard)
-  @Post('login/local')
+  @Post('login')
   @applyDecorators(...ApiLogin())
   async loginLocal(@Request() req: { user: JwtPayload }) {
     return this.authService.login(req.user);

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -147,7 +147,7 @@ export class AuthService {
     }
 
     // 역할 검증
-    const isMover = role === Role.MOVER;
+    const isMover = user.role === Role.MOVER;
     if (user.role !== role) {
       const roleLabel = isMover ? '기사님' : '고객님';
       throw new BadRequestException(`${email}은 ${roleLabel} 계정입니다!`);
@@ -287,10 +287,15 @@ export class AuthService {
     const user = await this.userRepository.findOneBy({ id: userId });
 
     if (!user) {
-      throw new NotFoundException('유저를 찾을 수 없습니다.');
+      throw new NotFoundException('사용자를 찾을 수 없습니다.');
     }
 
-    await this.userRepository.update(user.id, { refreshToken: null });
+    const isSocialLogin = user.provider !== Provider.LOCAL;
+    if (isSocialLogin) {
+      await this.userRepository.update(user.id, { providerId: null }); // provider id null로 설정하여 무효화
+    }
+
+    await this.userRepository.update(user.id, { refreshToken: null }); // 리프레시 토큰을 null로 설정하여 무효화
 
     return {
       message: '로그아웃 되었습니다.',

--- a/src/auth/docs/swagger.ts
+++ b/src/auth/docs/swagger.ts
@@ -90,7 +90,7 @@ export const ApiLogin = () => [
     description: `
     - Local strategy를 통해 로그인을 수행하고, 액세스/리프레시 토큰을 발급합니다.
     - 로그인 시 이메일과 비밀번호를 입력받습니다.
-    - 역할(role)은 'CUSTOMER' 또는 'ADMIN' 중 하나로 지정해야 합니다.
+    - 역할(role)은 'CUSTOMER' 또는 'MOVER' 중 하나로 지정해야 합니다.
     - role은 로그인을 시도하는 사용자의 역할이다. 예를 들어 기사님 페이지에서 로그인 시도를 할 경우 role은 'MOVER'이다.
     `,
   }),
@@ -103,7 +103,7 @@ export const ApiLogin = () => [
         password: { type: 'string', example: 'P@ssw0rd!' },
         role: {
           type: 'enum',
-          enum: ['CUSTOMER', 'ADMIN'],
+          enum: ['CUSTOMER', 'MOVER'],
           example: 'CUSTOMER',
         },
       },

--- a/src/auth/dto/local-login.dto.ts
+++ b/src/auth/dto/local-login.dto.ts
@@ -1,0 +1,23 @@
+import { Role } from '@/user/entities/user.entity';
+import { IsEmail, IsEnum, IsString, Length, Matches } from 'class-validator';
+
+export class LocalLoginDto {
+  @IsEmail({}, { message: '유효한 이메일 주소를 입력해주세요.' })
+  email: string;
+
+  @IsString()
+  @Length(8, 20, { message: '비밀번호는 8자 이상 20자 이하로 입력해주세요.' })
+  @Matches(
+    /^(?!.*\s)(?=.*[A-Za-z])(?=.*\d)(?=.*[!@#$%^&*()\-_=+{};:,<.>]).{8,20}$/,
+    {
+      message:
+        '비밀번호는 영문, 숫자, 특수문자를 모두 포함해야 하며 공백 없이 입력해야 합니다.',
+    },
+  )
+  password: string;
+
+  @IsEnum(Role, {
+    message: '역할(role) 값은 반드시 MOVER, CUSTOMER 중 하나여야 합니다.',
+  })
+  role: Role;
+}

--- a/src/auth/strategy/local.strategy.ts
+++ b/src/auth/strategy/local.strategy.ts
@@ -4,6 +4,9 @@ import { Strategy } from 'passport-local';
 import { AuthService } from '../auth.service';
 import { Request } from 'express';
 import { Provider, Role } from '@/user/entities/user.entity';
+import { validateSync, ValidationError } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+import { LocalLoginDto } from '../dto/local-login.dto';
 
 export class LocalAuthGuard extends AuthGuard('local') {}
 
@@ -25,12 +28,21 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
    */
   async validate(req: Request, email: string, password: string) {
     // role 유효성 검사
-    const role = req.query.state as Role;
-    if (!role || !Object.values(Role).includes(role)) {
-      throw new BadRequestException('유효하지 않은 역할이 제공되었습니다.');
+    const { role } = req.body as { role: Role }; // body에서 role 추출
+
+    // DTO 인스턴스 생성
+    const dto = plainToInstance(LocalLoginDto, { email, password, role });
+
+    // dto 검증 수행
+    const errors = validateSync(dto);
+
+    // 모든 에러메시지를 배열로 반환
+    if (errors.length > 0) {
+      const allMessages = this.getAllErrorMessages(errors);
+      throw new BadRequestException(allMessages);
     }
 
-    // 사용자 조회
+    // 사용자 인증
     const user = await this.authService.authenticate(
       role,
       Provider.LOCAL,
@@ -46,5 +58,28 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     };
 
     return payload;
+  }
+
+  /**
+   * 모든 ValidationError 메시지를 가져오는 함수
+   * 재귀적으로 모든 에러 메시지를 수집합니다.
+   *
+   * @param errors
+   * @returns
+   */
+
+  private getAllErrorMessages(errors: ValidationError[]): string[] {
+    let messages: string[] = [];
+
+    for (const err of errors) {
+      if (err.constraints) {
+        messages.push(...Object.values(err.constraints));
+      }
+
+      if (err.children && err.children.length) {
+        messages = messages.concat(this.getAllErrorMessages(err.children));
+      }
+    }
+    return messages;
   }
 }

--- a/src/common/docs/body.swagger.ts
+++ b/src/common/docs/body.swagger.ts
@@ -117,3 +117,27 @@ export const GetMoverProfilesNoFilterWithCursorExample = {
     },
   },
 };
+
+export const localRegisterExample = {
+  summary: 'local 회원가입 예시',
+  value: {
+    role: 'CUSTOMER',
+    name: '홍길동',
+    phone: '01012345678',
+    email: 'hong@example.com',
+    password: 'P@ssw0rd!',
+  },
+};
+
+export const snsRegisterExample = {
+  summary: 'sns 회원가입 예시',
+  value: {
+    role: 'MOVER',
+    name: '무빙이',
+    phone: '01098765432',
+    email: 'moving@example.com',
+    password: 'Moving@1234',
+    provider: 'NAVER',
+    providerId: 'naver-user-id-12345',
+  },
+};

--- a/src/common/docs/validation.swagger.ts
+++ b/src/common/docs/validation.swagger.ts
@@ -24,6 +24,26 @@ export const nameValidationError = {
   },
 };
 
+export const roleValidationError = {
+  key: 'roleValidationError',
+  summary: '역할 유효성 실패',
+  value: {
+    statusCode: 400,
+    message: ['역할(role) 값은 반드시 MOVER, CUSTOMER 중 하나여야 합니다.'],
+    error: 'Bad Request',
+  },
+};
+
+export const emailValidationError = {
+  key: 'emailValidationError',
+  summary: '이메일 유효성 실패',
+  value: {
+    statusCode: 400,
+    message: ['유효한 이메일 주소를 입력해주세요.'],
+    error: 'Bad Request',
+  },
+};
+
 export const passwordValidationError = {
   key: 'passwordValidationError',
   summary: '비밀번호 유효성 실패',

--- a/src/user/dto/create-user.dto.ts
+++ b/src/user/dto/create-user.dto.ts
@@ -43,7 +43,8 @@ export class CreateUserDto {
   password?: string;
 
   @IsEnum(Provider)
-  provider: Provider; // 로그인 제공자 (예: 'local', 'naver', 'kakao', 'google' 등)
+  @IsOptional()
+  provider?: Provider = Provider.LOCAL; // 로그인 제공자 (예: 'local', 'naver', 'kakao', 'google' 등)
 
   @IsString()
   @IsOptional()

--- a/src/user/entities/user.entity.ts
+++ b/src/user/entities/user.entity.ts
@@ -46,7 +46,7 @@ export class User extends BaseTable {
   @Column({ nullable: true })
   password?: string;
 
-  @Column({ type: 'enum', enum: Provider })
+  @Column({ type: 'enum', enum: Provider, default: Provider.LOCAL })
   provider: Provider;
 
   @Column({ nullable: true })


### PR DESCRIPTION
## 🧚 변경사항 설명

- [f544ba1](https://github.com/FS05-PART4-TEAM1/5-moving-team1-be/pull/46/commits/f544ba1a76342de4b9934006b38901b521bec58c): provider 기본값 설정
- [729b84c](https://github.com/FS05-PART4-TEAM1/5-moving-team1-be/pull/46/commits/729b84c82cfb0308bed2b6910f4729b66cb196c0): local login url 변경
- [3952422](https://github.com/FS05-PART4-TEAM1/5-moving-team1-be/pull/46/commits/395242256bf479049d25aa8893e41cf390094d62): auth 서비스 리팩토링 (authenticate는 user.role과 비교로 수정, logout은 sns 로그인시 providerId 초기화 로직 추가)
- [c912ba8](https://github.com/FS05-PART4-TEAM1/5-moving-team1-be/pull/46/commits/c912ba8dc791f373ce702758c7ec1906b6fd9b9d): local auth guard에서 dto처리
- [97bebad](https://github.com/FS05-PART4-TEAM1/5-moving-team1-be/pull/46/commits/97bebadd9b712f1ac6f5c761260e7f1168d66747): 회원가입 및 로그인 swagger 리팩토링

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

<!-- 기타 팀원들이 참고해야 할 사항이 있으면 작성해주세요  -->

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

<!-- 기능 완성 PR의 경우 UI 변경사항, API 호출 테스트 결과 등의 스크린샷을 첨부해주세요 -->
