### PR TITLE
refactor/대기중 견적 목록 및 상세조회 url pending 추가

### DIFF
--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -15,7 +15,7 @@ import { ENTITIES } from './database.entities';
         password: configService.get<string>(envVariableKeys.dbPassword),
         database: configService.get<string>(envVariableKeys.dbDatabase),
         entities: ENTITIES,
-        synchronize: true,
+        synchronize: false,
         ssl: { rejectUnauthorized: false },
       }),
       inject: [ConfigService],

--- a/src/estimate-offer/entities/estimate-offer.entity.ts
+++ b/src/estimate-offer/entities/estimate-offer.entity.ts
@@ -12,8 +12,6 @@ import {
 } from 'typeorm';
 
 export enum OfferStatus {
-  // SUBMITTED = 'SUBMITTED', // 기사님이 견적서 보냄 //TODO: 이거 주석처리했더니 이미 DB에 SUBMITTED 로 저장된 상태가 있어서 에러 발생해서 우선 살려둠
-  //중간테이블 만드는 부분 내일 논의 후에 확정되면 마이그레이션 진행 해야할거같아요.
   PENDING = 'PENDING', // 고객이 견적 요청 보냄 (기사 입장에선 대기 중)
   CONFIRMED = 'CONFIRMED', // 고객이 확정함
   CANCELED = 'CANCELED', // 고객이 다른 기사 선택 → 자동 취소

--- a/src/estimate-offer/estimate-offer.controller.ts
+++ b/src/estimate-offer/estimate-offer.controller.ts
@@ -17,7 +17,7 @@ export class EstimateOfferController {
   constructor(private readonly estimateOfferService: EstimateOfferService) {}
 
   // 견적 요청 ID로 대기 중인 견적 목록 조회
-  @Get(':requestId')
+  @Get(':requestId/pending')
   @RBAC(Role.CUSTOMER)
   @ApiGetPendingEstimateOffers()
   async getOffersByEstimateRequestId(
@@ -31,7 +31,7 @@ export class EstimateOfferController {
   }
 
   // 견적 요청 ID와 기사 ID로 견적 제안 상세 조회
-  @Get(':requestId/:moverId')
+  @Get(':requestId/:moverId/pending')
   @RBAC(Role.CUSTOMER)
   @ApiGetEstimateOfferDetail()
   async getOfferDetail(


### PR DESCRIPTION
## 🧚 변경사항 설명
- 기존 (대기중인)받은 견적 목록 조회 (고객)  & (대기중인)받은 견적 상세 조회 (고객) url 에 pending 추가
![image](https://github.com/user-attachments/assets/08f7697c-a0f1-402c-b0ab-d2b0d83eccce)

- DB 엔티티에  synchronize 옵션이 true 로 되어있어서 에러발생해서 false로 수정
- estimate-offer 상태 필요없는 주석 제거 

## 🎤 공유 사항

- 해당 API 사용하는 프론트 담당하시는 @Bear4243  민호님 참고해주세요.

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

<!-- 기능 완성 PR의 경우 UI 변경사항, API 호출 테스트 결과 등의 스크린샷을 첨부해주세요 -->
