### PR TITLE
feat:해당고객의 진행중인 견적요청ID 조회 API(개발용)

### DIFF
--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -94,3 +94,24 @@ export function ApiGetMyEstimateHistory() {
     }),
   );
 }
+export function ApiGetMyActiveEstimateRequest() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '진행 중인 견적 요청 ID 조회 (개발용)',
+      description: 'PENDING, CONFIRMED 상태의 견적 요청 ID만 반환합니다.',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '진행 중인 estimateRequestId 리스트',
+      schema: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            estimateRequestId: { type: 'string', example: 'uuid-example' },
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -18,6 +18,7 @@ import { RBAC } from '@/auth/decorator/rbac.decorator';
 import { Role } from '@/user/entities/user.entity';
 import {
   ApiCreateEstimateRequest,
+  ApiGetMyActiveEstimateRequest,
   ApiGetMyEstimateHistory,
 } from './docs/swagger';
 
@@ -27,6 +28,13 @@ export class EstimateRequestController {
   constructor(
     private readonly estimateRequestService: EstimateRequestService,
   ) {}
+  //INFO: 개발용 해당 고객의 진행 중인 견적 요청 ID 조회 API
+  @Get('active')
+  @ApiGetMyActiveEstimateRequest()
+  @RBAC(Role.CUSTOMER)
+  async getMyActiveEstimateRequest(@UserInfo() user: UserInfo) {
+    return this.estimateRequestService.findActiveEstimateRequestIds(user.sub);
+  }
 
   @Post()
   @RBAC(Role.CUSTOMER)

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -26,7 +26,32 @@ export class EstimateRequestService {
 
     private readonly dataSource: DataSource,
   ) {}
-
+  /**
+   * 고객의 진행중인(pending, confirmed) 견적 요청 ID 조회 - //TODO: 개발용이므로 추후 삭제 예정
+   * @param userId 고객 ID
+   * @returns { estimateRequestId: string }[]
+   */
+  async findActiveEstimateRequestIds(
+    userId: string,
+  ): Promise<{ estimateRequestId: string }[]> {
+    return this.estimateRequestRepository
+      .find({
+        where: {
+          customer: { user: { id: userId } },
+          status: In([RequestStatus.PENDING, RequestStatus.CONFIRMED]),
+        },
+        select: { id: true }, // `id`만 반환
+      })
+      .then((requests) =>
+        requests.map((req) => ({ estimateRequestId: req.id })),
+      );
+  }
+  /**
+   * 견적 요청 생성
+   * @param dto CreateEstimateRequestDto
+   * @param user UserInfo
+   * @returns { id: string, message: string }
+   */
   async create(dto: CreateEstimateRequestDto, user: UserInfo) {
     // 1. 로그인한 유저의 CustomerProfile 가져오기
     const customer = await this.customerProfileRepository.findOne({


### PR DESCRIPTION
## 🧚 변경사항 설명

- 해당 고객의 진행중인 견적요청 ID만 조회하는 개발용 API입니다.
- 저희가 견적요청ID에 대한 offer 목록 조회 API만 있어서 견적요청 ID를 (DB조회하면 되긴하는데)빠르게 조회하기위해서 스웨거 설정해두었습니다. 
- 추후 qa때 필요없어지면 삭제하면 될 것 같습니다. 


## 🎤 공유 사항

경로 : api/estimate-request/active

Closes #

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/88f08da4-b797-4837-9c8f-b010f6951ab8)
![image](https://github.com/user-attachments/assets/cbc2578b-ad10-4e6d-a0a8-bacb3f66792a)

