### PR TITLE
feat: sentry 알림 전송시 로컬 경로 마스킹 처리 및 테스트 환경

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -24,6 +24,7 @@ import { ResponseTimeInterceptor } from './common/interceptor/response-time.inte
 import { S3Module } from './s3/s3.module';
 import { DatabaseModule } from './database/database.module';
 import { databaseValidationSchema } from './database/database.config';
+import { TestErrorController } from './common/utils/test-error.controller';
 
 const appValidationSchema = Joi.object({
   // 애플리케이션 실행 환경 설정 ('dev' 또는 'prod'만 허용)
@@ -63,6 +64,7 @@ const appValidationSchema = Joi.object({
     AuthModule,
     S3Module,
   ],
+  controllers: [TestErrorController],
   providers: [
     {
       provide: 'APP_GUARD',

--- a/src/common/filter/all-exceptions.filter.ts
+++ b/src/common/filter/all-exceptions.filter.ts
@@ -53,7 +53,7 @@ export class AllExceptionsFilter implements ExceptionFilter {
 
       Sentry.captureException(exception); //Sentry로 에러 전송
       await sendDiscordAlert(exception, `${method} ${url}`); //Discord Webhook으로 알림 전송
-      exception = new InternalServerErrorException(); // 숨김 처리
+      exception = new InternalServerErrorException(); //클라이언트에 노출 X
     }
 
     const responseBody =

--- a/src/common/utils/discord-notifier.util.ts
+++ b/src/common/utils/discord-notifier.util.ts
@@ -1,5 +1,8 @@
 import axios from 'axios';
 
+/**
+ * Discord Webhook 알림 전송 함수
+ */
 export async function sendDiscordAlert(
   error: unknown,
   context = 'Unknown context',
@@ -12,10 +15,7 @@ export async function sendDiscordAlert(
 
   const safe = (val: unknown) => (val ? String(val) : '(unknown)');
   const message = error instanceof Error ? error.message : safe(error);
-  const stack =
-    error instanceof Error
-      ? error.stack?.split('\n').slice(0, 5).join('\n')
-      : '';
+  const stack = error instanceof Error ? maskStackTrace(error.stack) : '';
 
   const content = `🚨 **Server Error Alert**
 **Context**: ${context}
@@ -29,4 +29,22 @@ export async function sendDiscordAlert(
   } catch (err) {
     console.error('❌ Discord Webhook 전송 실패:', err);
   }
+}
+/**
+ * 스택트레이스를 최대 5줄까지 가져오고, 절대경로 마스킹 처리
+ */
+function maskStackTrace(stack?: string): string {
+  if (!stack) return '';
+
+  // 현재 작업 디렉토리를 정규화
+  const projectRoot = process.cwd().replace(/\\/g, '/');
+
+  return stack
+    .split('\n')
+    .slice(0, 5)
+    .map((line) => {
+      const normalizedLine = line.replace(/\\/g, '/');
+      return normalizedLine.replace(projectRoot, '[app-root]');
+    })
+    .join('\n');
 }

--- a/src/common/utils/test-error.controller.ts
+++ b/src/common/utils/test-error.controller.ts
@@ -1,0 +1,9 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller('test-error')
+export class TestErrorController {
+  @Get('throw')
+  throwError() {
+    throw new Error('🔥 웹훅 알림 테스트');
+  }
+}


### PR DESCRIPTION
## 🧚 변경사항 설명

- 백엔드 에러 알림 디스코드 웹훅 연결 테스트 완료
- 알림 전송시 로컬 경로 마스킹 처리하는 함수 추가
- 테스트 파일 (src\common\utils\test-error.controller.ts) 추가
- 테스트 파일은 스크럼 때 다들 적용 잘 됬는지 확인해보는 용도로 사용 후 삭제해도 될 것 같습니다. 


## 🎤 공유 사항

- 관련 환경변수 .env 파일 #Sentry 부분에 추가해두었습니다. 

## 🤙🏻 관련 이슈


Closes #48 

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/a37ac346-e108-4363-9e2d-37d3623b0991)
