### PR TITLE
feat/견적 요청에 지정 견적 기사 추가 PATCH API 

### DIFF
--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -3,6 +3,9 @@ import {
   ApiResponse,
   ApiBearerAuth,
   ApiBody,
+  ApiTags,
+  ApiQuery,
+  ApiParam,
 } from '@nestjs/swagger';
 import { applyDecorators } from '@nestjs/common';
 
@@ -113,5 +116,71 @@ export function ApiGetMyActiveEstimateRequest() {
         },
       },
     }),
+  );
+}
+export function ApiAddTargetMover() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '지정 기사 추가',
+      description:
+        '특정 견적 요청 ID(requestId)에 지정 기사를 추가합니다. 최대 3명까지 추가할 수 있습니다.',
+    }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'requestId',
+      required: true,
+      description: '지정 기사를 추가할 견적 요청 ID',
+      example: '52145515-6fd9-4ecd-9fd8-7106fbce9765',
+    }),
+    ApiBody({
+      schema: {
+        type: 'object',
+        properties: {
+          moverId: {
+            type: 'string',
+            format: 'uuid',
+            example: '9ec9e7ba-d922-48b4-a821-17842bc02944',
+            description: '추가할 기사님 ID (MoverId)',
+          },
+        },
+        required: ['moverId'],
+      },
+    }),
+    ApiResponse({
+      status: 200,
+      description: '지정 기사 추가 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '🧑‍🔧 김기사님이 지정 견적 기사로 추가되었습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse(
+      CODE_400_BAD_REQUEST([
+        {
+          key: 'AlreadyTargetedMover',
+          summary: '이미 지정된 기사',
+          value: {
+            statusCode: 400,
+            message: '이미 지정 기사로 추가된 기사님입니다.',
+            error: 'Bad Request',
+          },
+        },
+        {
+          key: 'MaxTargetMoversReached',
+          summary: '지정 기사 수 초과',
+          value: {
+            statusCode: 400,
+            message: '지정 기사는 최대 3명까지 추가할 수 있습니다.',
+            error: 'Bad Request',
+          },
+        },
+      ]),
+    ),
+    ApiResponse(CODE_401_RESPONSES),
   );
 }

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -3,20 +3,21 @@ import {
   Get,
   Post,
   Body,
+  Query,
   Patch,
   Param,
-  Delete,
 } from '@nestjs/common';
 import { EstimateRequestService } from './estimate-request.service';
 import { CreateEstimateRequestDto } from './dto/create-estimate-request.dto';
 
-import { UpdateEstimateRequestDto } from './dto/update-estimate-request.dto';
+// import { UpdateEstimateRequestDto } from './dto/update-estimate-request.dto';
 
 import { UserInfo } from '@/user/decorator/user-info.decorator';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { RBAC } from '@/auth/decorator/rbac.decorator';
 import { Role } from '@/user/entities/user.entity';
 import {
+  ApiAddTargetMover,
   ApiCreateEstimateRequest,
   ApiGetMyActiveEstimateRequest,
   ApiGetMyEstimateHistory,
@@ -53,14 +54,20 @@ export class EstimateRequestController {
     return this.estimateRequestService.findAllRequestHistory(user.sub);
   }
 
-  // @Patch(':id')
-  // update(
-  //   @Param('id') id: string,
-  //   @Body() updateEstimateRequestDto: UpdateEstimateRequestDto,
-  // ) {
-  //   return this.estimateRequestService.update(+id, updateEstimateRequestDto);
-  // }
-
+  @Patch(':requestId/targeted')
+  @RBAC(Role.CUSTOMER)
+  @ApiAddTargetMover()
+  async addTargetedMover(
+    @Param('requestId') estimateRequestId: string,
+    @Body() body: { moverId: string },
+    @UserInfo() user: UserInfo,
+  ) {
+    return this.estimateRequestService.addTargetMover(
+      estimateRequestId,
+      body.moverId,
+      user.sub,
+    );
+  }
   // @Delete(':id')
   // remove(@Param('id') id: string) {
   //   return this.estimateRequestService.remove(+id);

--- a/src/estimate-request/estimate-request.module.ts
+++ b/src/estimate-request/estimate-request.module.ts
@@ -1,15 +1,19 @@
 import { Module } from '@nestjs/common';
 import { EstimateRequestService } from './estimate-request.service';
 import { EstimateRequestController } from './estimate-request.controller';
-import { Type } from 'class-transformer';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EstimateRequest } from './entities/estimate-request.entity';
 import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
 import { EstimateOffer } from '@/estimate-offer/entities/estimate-offer.entity';
-
+import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
 @Module({
   imports: [
-    TypeOrmModule.forFeature([EstimateRequest, CustomerProfile, EstimateOffer]),
+    TypeOrmModule.forFeature([
+      EstimateRequest,
+      CustomerProfile,
+      MoverProfile,
+      EstimateOffer,
+    ]),
   ],
   controllers: [EstimateRequestController],
   providers: [EstimateRequestService],

--- a/src/mover-profile/mover-profile.module.ts
+++ b/src/mover-profile/mover-profile.module.ts
@@ -22,6 +22,6 @@ import { Review } from '@/review/entities/review.entity';
   ],
   controllers: [MoverProfileController],
   providers: [MoverProfileService],
-  exports: [MoverProfileService],
+  exports: [MoverProfileService, TypeOrmModule],
 })
 export class MoverProfileModule {}


### PR DESCRIPTION
## 🧚 변경사항 설명

- 고객이 특정 견적 요청에 대해 기사를 지정하여 지정 견적 기사배열에(targetedMoverIds[]) 추가하는 PATCH API 입니다.
- EstimateRequestResponseDto 를 수정하여 재사용
- 스웨거 설정 완료

## 🧑🏻‍🏫 To-do

- 기사가 견적 요청 목록 조회하는 API 구현( filter 적용)
- 서버 로그를 포매팅해두었더니 자세하게 찍히지 않아 디버깅이 어려워서 에러 로그를 좀 더 자세하게 보여주도록 포맷팅 수정
- seed 데이터 
- 커서 페이지네이션


## 🤙🏻 관련 이슈

Closes #53

## 📸 스크린샷
![Screenshot 2025-06-12 183358](https://github.com/user-attachments/assets/3494c570-77a7-4aa4-b4b2-309004a559c5)
![Screenshot 2025-06-12 183228](https://github.com/user-attachments/assets/49d38ab5-0f4a-43dd-816d-3b729177863d)
![Screenshot 2025-06-12 181424](https://github.com/user-attachments/assets/f1196967-e49b-4f10-96e2-8474981f7afb)

