### PR TITLE
refactor: 서버로그 포맷팅 및 로그 색상 변경

### DIFF
--- a/src/common/utils/format-error-log.ts
+++ b/src/common/utils/format-error-log.ts
@@ -1,11 +1,34 @@
-//sentry 에러 로깅 포맷 함수
-//다음과 같은 형식으로 로그를 남김
-//[Nest] 13156  - 06/11/2025, 3:34:43 PM   ERROR [AllExceptionsFilter] [GET] /api/auth/sentry-test → 500 | Internal server error
-export function formatErrorLog(
-  method: string,
-  url: string,
-  status: number,
-  message: string,
-): string {
-  return `[${method}] ${url} → ${status} | ${message}`;
+// //sentry 에러 로깅 포맷 함수
+// //다음과 같은 형식으로 로그를 남김
+// //[Nest] 13156  - 06/11/2025, 3:34:43 PM   ERROR [AllExceptionsFilter] [GET] /api/auth/sentry-test → 500 | Internal server error
+// export function formatErrorLog(
+//   method: string,
+//   url: string,
+//   status: number,
+//   message: string,
+// ): string {
+//   return `[${method}] ${url} → ${status} | ${message}`;
+// }
+//
+
+//에러 로그 좀 더 자세히 남기도록 수정
+export function formatErrorLog({
+  method,
+  url,
+  status,
+  message,
+  userId,
+  stack,
+}: {
+  method: string;
+  url: string;
+  status: number;
+  message: string;
+  userId?: string;
+  stack?: string;
+}): string {
+  const timestamp = new Date().toISOString();
+  const userLine = userId ? ` | user: ${userId}` : '';
+  const header = `[${timestamp}] [${method}] ${url} → ${status} | ${message}${userLine}`;
+  return stack ? `${header}\n${stack}` : header;
 }


### PR DESCRIPTION
## 🧚 변경사항 설명

- 개발중 서버 로그 더 자세히 찍도록 수정
- nest js 에러 로그 글자 빨간색 눈 아파서 제목 말고 내용은 회색으로 찍히도록 chalk 라이브러리 설치하여 로그 색상 커스터마이징
- 디스코드 알림 글자수 제한 설정

## 🎤 공유 사항

- 라이브러리 설치 있어서 pull 받고 npm install 한번 해주세요~

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #


## 📸 스크린샷
- 에러 로그 색상 적용 전
![Screenshot 2025-06-13 045549](https://github.com/user-attachments/assets/b302c9f0-6464-4c80-bcb2-e30086e98c74)
- 적용 후 
![Screenshot 2025-06-13 045501](https://github.com/user-attachments/assets/2ef057b5-bad0-4968-bfee-25b6a60d6b25)
