### PR TITLE
Feat/(기사가) 받은 견적 요청 조회

### DIFF
--- a/src/common/dto/cursor-pagination.dto.ts
+++ b/src/common/dto/cursor-pagination.dto.ts
@@ -6,7 +6,8 @@ export enum OrderField {
   AVERAGE_RATING = 'average_rating', // 평균 평점
   EXPERIENCE = 'experience', // 경력
   CONFIRMED_ESTIMATE_COUNT = 'confirmed_estimate_count', // 확정 견적 수
-  CREATED_AT = 'created_at', // 생성일 DESC 최신순
+  CREATED_AT = 'createdAt',
+  MOVE_DATE = 'moveDate', // 이사 날짜
 }
 
 export enum OrderDirection {

--- a/src/common/dto/paginated-response.dto.ts
+++ b/src/common/dto/paginated-response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+/**
+ * GenericPaginatedDto<T>
+ *
+ * 커서 기반 페이지네이션 응답 형식을 공통으로 정의하는 제네릭 클래스
+ * 다양한 도메인(DTO) 타입에 대응할 수 있도록 제네릭으로 구현
+ * 다양한 커서 페이지네이션 리스트 응답에 재사용 가능
+ *
+ * 예시 응답 형태:
+ * {
+ *   items: [...],
+ *   nextCursor: '2025-07-10T00:00:00.000Z',
+ *   hasNext: true,
+ *   totalCount: 42
+ * }
+ */
+export class GenericPaginatedDto<T> {
+  @ApiProperty({ isArray: true })
+  items: T[];
+
+  @ApiProperty({ example: '2025-07-10T00:00:00.000Z', nullable: true })
+  nextCursor: string | null;
+
+  @ApiProperty({ example: true })
+  hasNext: boolean;
+
+  @ApiProperty({ example: 25 })
+  totalCount: number;
+}

--- a/src/estimate-request/dto/estimate-request-pagination.dto.ts
+++ b/src/estimate-request/dto/estimate-request-pagination.dto.ts
@@ -1,0 +1,36 @@
+import { OrderField } from '@/common/dto/cursor-pagination.dto';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
+/**
+ * EstimateRequestPaginationDto
+ *
+ * 기사 전용 견적 요청 목록 API에서 커서 기반 페이지네이션을 처리하기 위한 DTO
+ *
+ * - `cursor`: 현재 페이지의 마지막 요소를 기준으로 다음 데이터를 가져올 때 사용하는 커서 값
+ * - `orderField`: 정렬 기준 필드 (기본값: moveDate).
+ * - `take`: 가져올 데이터 개수 (기본값: 5)
+ *
+ *  `order` 필드나 `orderDirection`이 불필요해서 혼동을 줄이기 위해
+ *   해당 API에서 필요한 필드만 명시적으로 선언해서 사용하기 위해 CursorPaginationDto extends 하지 않음
+ *
+ */
+export class EstimateRequestPaginationDto {
+  @IsString()
+  @IsOptional()
+  cursor?: string;
+
+  @Transform(({ value }) => {
+    const map = {
+      move_date: OrderField.MOVE_DATE,
+      created_at: OrderField.CREATED_AT,
+    };
+    return map[value] || value;
+  })
+  @IsEnum(OrderField)
+  @IsOptional()
+  orderField?: OrderField = OrderField.MOVE_DATE;
+
+  @IsInt()
+  @IsOptional()
+  take?: number = 5;
+}

--- a/src/estimate-request/dto/estimate-request-response.dto.ts
+++ b/src/estimate-request/dto/estimate-request-response.dto.ts
@@ -28,11 +28,12 @@ export class EstimateRequestResponseDto {
    */
   static from(
     request: EstimateRequest,
-    offers: EstimateOfferResponseDto[],
+    offers?: EstimateOfferResponseDto[],
     options?: {
       includeAddress?: boolean;
       includeMinimalAddress?: boolean;
     },
+    isTargeted?: boolean,
   ): EstimateRequestResponseDto {
     const dto = new EstimateRequestResponseDto();
 
@@ -40,11 +41,9 @@ export class EstimateRequestResponseDto {
     dto.createdAt = request.createdAt;
     dto.moveType = request.moveType;
     dto.moveDate = request.moveDate;
-    dto.estimateOffers = offers;
+    dto.estimateOffers = offers ?? [];
 
-    dto.isTargeted =
-      Array.isArray(request.targetMoverIds) &&
-      request.targetMoverIds.length > 0;
+    dto.isTargeted = isTargeted ?? false;
 
     dto.customerName = request.customer?.user?.name ?? null;
 

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -68,6 +68,14 @@ export class EstimateRequestController {
       user.sub,
     );
   }
+
+  //Mover가 견적 요청 목록 조회
+  @Get('/')
+  @RBAC(Role.MOVER)
+  async getRequestListForMover(@UserInfo() user: UserInfo) {
+    return this.estimateRequestService.findRequestListForMover(user.sub);
+  }
+
   // @Delete(':id')
   // remove(@Param('id') id: string) {
   //   return this.estimateRequestService.remove(+id);

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -9,9 +9,6 @@ import {
 } from '@nestjs/common';
 import { EstimateRequestService } from './estimate-request.service';
 import { CreateEstimateRequestDto } from './dto/create-estimate-request.dto';
-
-// import { UpdateEstimateRequestDto } from './dto/update-estimate-request.dto';
-
 import { UserInfo } from '@/user/decorator/user-info.decorator';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { RBAC } from '@/auth/decorator/rbac.decorator';
@@ -22,6 +19,8 @@ import {
   ApiGetMyActiveEstimateRequest,
   ApiGetMyEstimateHistory,
 } from './docs/swagger';
+import { ApiGetRequestListForMover } from './docs/swagger';
+import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
 
 @ApiBearerAuth()
 @Controller('estimate-request')
@@ -72,8 +71,15 @@ export class EstimateRequestController {
   //Mover가 견적 요청 목록 조회
   @Get('/')
   @RBAC(Role.MOVER)
-  async getRequestListForMover(@UserInfo() user: UserInfo) {
-    return this.estimateRequestService.findRequestListForMover(user.sub);
+  @ApiGetRequestListForMover()
+  async getRequestListForMover(
+    @UserInfo() user: UserInfo,
+    @Query() pagination: EstimateRequestPaginationDto,
+  ) {
+    return this.estimateRequestService.findRequestListForMover(
+      user.sub,
+      pagination,
+    );
   }
 
   // @Delete(':id')


### PR DESCRIPTION
## 🧚 변경사항 설명

- 기사 전용(RBAC: MOVER) 견적 요청 목록 조회 API  (GET  /api/estimate-request)
- 정렬 기준은 이사일(moveDate) 또는 요청일(createdAt) 중 선택할 수 있고, 둘 다 '빠른 순' 오름차순(ASC) 정렬만 적용했습니다.
- 본인이 지정 견적 대상인 요청(request.targetMoverIds에 본인 ID가 포함된 경우)은 응답에 isTargeted: true로 표시됩니다.

3d39fb5cfef728509808da293a250a57c07ba167 :
- 기존 /common/dto/cursor-pagination.dto.ts에 정의된 공통 DTO 사용해보려고했는데, 현재 구현한 api에는 사용하지 않는 정렬 옵션들이 스웨거에 상속되어 뜨는 등 혼동이 있을 것 같아서 필요한 필드만 명시적으로 사용하기 위해 EstimateRequestPaginationDto 따로 추가해서 사용했습니다. 
- /common/dto/paginated-response.dto.ts에 커서 기반 페이지네이션 응답 구조를 제네릭 DTO로 분리해 공통화했습니다.
  - 다양한 리스트 조회 API에서 GenericPaginatedDto<...> 형태로 재사용 가능하며, Swagger 문서도 일관된 포맷으로 노출됩니다. 
  - 서비스 함수에서 GenericPaginatedDto<EstimateRequestResponseDto> 형태로 사용
![image](https://github.com/user-attachments/assets/645e10d0-83b4-452a-bb41-eb6dd09b78ca)
![image](https://github.com/user-attachments/assets/e7641807-c1f5-4801-ab4a-aadf51e8fcb1)

## 🧑🏻‍🏫 To-do

- 커서 페이지네이션 적용 필요한 다른 API들 리팩토링
- 구글 소셜 로그인

## 🎤 공유 사항

- 프론트 담당자 @celina823 님 참고해주세요 :) https://www.notion.so/1f8d9fa672ba8046b9d5f436880d9b1b?source=copy_link

## 🤙🏻 관련 이슈


Closes #65


## 📸 스크린샷
![image](https://github.com/user-attachments/assets/7cf73995-eeb0-4e90-9790-9f050ee1c7d2)
![image](https://github.com/user-attachments/assets/4e542e85-1849-4fa4-bf23-23f029978ccb)


