### PR TITLE
Refactor/받았던 견적 목록(history) 커서 페이지네이션 추가

### DIFF
--- a/src/common/dto/created-at-pagination.dto.ts
+++ b/src/common/dto/created-at-pagination.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString, IsInt } from 'class-validator';
+
+export class CreatedAtCursorPaginationDto {
+  @IsString()
+  @IsOptional()
+  cursor?: string;
+
+  @IsInt()
+  @IsOptional()
+  take?: number = 5;
+}

--- a/src/common/dto/cursor-pagination.dto.ts
+++ b/src/common/dto/cursor-pagination.dto.ts
@@ -6,7 +6,8 @@ export enum OrderField {
   AVERAGE_RATING = 'average_rating', // 평균 평점
   EXPERIENCE = 'experience', // 경력
   CONFIRMED_ESTIMATE_COUNT = 'confirmed_estimate_count', // 확정 견적 수
-  CREATED_AT = 'created_at', // 생성일 DESC 최신순
+  CREATED_AT = 'createdAt',
+  MOVE_DATE = 'moveDate', // 이사 날짜
 }
 
 export enum OrderDirection {

--- a/src/common/dto/paginated-response.dto.ts
+++ b/src/common/dto/paginated-response.dto.ts
@@ -1,0 +1,29 @@
+import { ApiProperty } from '@nestjs/swagger';
+/**
+ * GenericPaginatedDto<T>
+ *
+ * 커서 기반 페이지네이션 응답 형식을 공통으로 정의하는 제네릭 클래스
+ * 다양한 도메인(DTO) 타입에 대응할 수 있도록 제네릭으로 구현
+ * 다양한 커서 페이지네이션 리스트 응답에 재사용 가능
+ *
+ * 예시 응답 형태:
+ * {
+ *   items: [...],
+ *   nextCursor: '2025-07-10T00:00:00.000Z',
+ *   hasNext: true,
+ *   totalCount: 42
+ * }
+ */
+export class GenericPaginatedDto<T> {
+  @ApiProperty({ isArray: true })
+  items: T[];
+
+  @ApiProperty({ example: '2025-07-10T00:00:00.000Z', nullable: true })
+  nextCursor: string | null;
+
+  @ApiProperty({ example: true })
+  hasNext: boolean;
+
+  @ApiProperty({ example: 25 })
+  totalCount: number;
+}

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -83,23 +83,52 @@ export function ApiGetMyEstimateHistory() {
     ApiOperation({
       summary: '받았던 견적 목록 조회',
       description:
-        '고객이 생성한 견적 요청 중 완료(COMPLETE), 취소(CANCELED), 만료(EXPIRED)된 요청 목록에 대해 받았던 견적서 목록을 조회합니다.',
+        '고객이 생성한 견적 요청 중 완료(COMPLETED), 취소(CANCELED), 만료(EXPIRED)된 요청 목록에 대해 받았던 견적서 목록을 커서 기반 페이지네이션 방식으로 조회합니다.\n정렬 기준은 생성일 최신 순`createdAt DESC`으로 고정되어있습니다.',
     }),
     ApiBearerAuth(),
-    ApiResponse({
-      status: 200,
-      description: '받았던 견적 목록 조회 성공',
-      type: EstimateRequestResponseDto,
-      isArray: true,
+    ApiQuery({
+      name: 'orderField',
+      required: false,
+      enum: ['createdAt'],
+      description: '정렬 기준 필드. createdAt',
+      example: 'createdAt',
     }),
-    ApiResponse({
-      status: 401,
-      description: '인증되지 않은 사용자',
+    ApiQuery({
+      name: 'cursor',
+      required: false,
+      description:
+        '커서 기준 값. 응답의 `nextCursor` 값을 복사해 다음 요청에 사용하세요.',
+      example: '2025-06-15T12:00:00.000Z',
     }),
-    ApiResponse({
-      status: 403,
-      description: '고객 권한이 없는 사용자',
+    ApiQuery({
+      name: 'take',
+      required: false,
+      description: '가져올 데이터 수 (기본값: 5)',
+      example: 5,
     }),
+
+    ApiExtraModels(GenericPaginatedDto, EstimateRequestResponseDto),
+    ApiOkResponse({
+      description: '견적 요청 목록 조회 성공',
+      schema: {
+        allOf: [
+          {
+            $ref: getSchemaPath(GenericPaginatedDto),
+          },
+          {
+            properties: {
+              items: {
+                type: 'array',
+                items: { $ref: getSchemaPath(EstimateRequestResponseDto) },
+              },
+            },
+          },
+        ],
+      },
+    }),
+
+    ApiResponse({ status: 401, description: '인증되지 않은 사용자' }),
+    ApiResponse({ status: 403, description: '고객 권한이 없는 사용자' }),
   );
 }
 export function ApiGetMyActiveEstimateRequest() {

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -83,16 +83,10 @@ export function ApiGetMyEstimateHistory() {
     ApiOperation({
       summary: '받았던 견적 목록 조회',
       description:
-        '고객이 생성한 견적 요청 중 완료(COMPLETED), 취소(CANCELED), 만료(EXPIRED)된 요청 목록에 대해 받았던 견적서 목록을 커서 기반 페이지네이션 방식으로 조회합니다.\n정렬 기준은 생성일 최신 순`createdAt DESC`으로 고정되어있습니다.',
+        '고객이 생성한 견적 요청 중 완료(COMPLETED), 취소(CANCELED), 만료(EXPIRED)된 요청 목록에 대해 받았던 견적서 목록을 커서 기반 페이지네이션 방식으로 조회합니다.\n정렬 기준은 생성일 최신 순(`createdAt DESC`)으로 고정되어 있습니다.',
     }),
     ApiBearerAuth(),
-    ApiQuery({
-      name: 'orderField',
-      required: false,
-      enum: ['createdAt'],
-      description: '정렬 기준 필드. createdAt',
-      example: 'createdAt',
-    }),
+
     ApiQuery({
       name: 'cursor',
       required: false,
@@ -126,11 +120,11 @@ export function ApiGetMyEstimateHistory() {
         ],
       },
     }),
-
     ApiResponse({ status: 401, description: '인증되지 않은 사용자' }),
     ApiResponse({ status: 403, description: '고객 권한이 없는 사용자' }),
   );
 }
+
 export function ApiGetMyActiveEstimateRequest() {
   return applyDecorators(
     ApiOperation({
@@ -234,21 +228,13 @@ export function ApiGetRequestListForMover() {
       required: false,
       description: '정렬 기준 필드 (예: 이사일 빠른 순 || 요청일 빠른 순)',
     }),
-    // ApiQuery({
-    //   name: 'orderDirection',
-    //   required: false,
-    //   enum: ['ASC'],
-    //   description: '정렬 방향 ASC 날짜 빠른 순',
-    //   example: 'ASC',
-    //   deprecated: true,
-    // }),
     ApiQuery({
       name: 'cursor',
       required: false,
       description:
-        '커서 기준 값. 응답의 `nextCursor` 값을 복사해 다음 요청에 사용하세요.',
-      example: '2025-06-15T12:00:00.000Z',
+        '이후 응답에서 받은 `nextCursor` 값을 사용해 다음 페이지를 조회하세요.',
     }),
+
     ApiQuery({
       name: 'take',
       required: false,

--- a/src/estimate-request/dto/estimate-request-pagination.dto.ts
+++ b/src/estimate-request/dto/estimate-request-pagination.dto.ts
@@ -23,6 +23,7 @@ export class EstimateRequestPaginationDto {
     const map = {
       move_date: OrderField.MOVE_DATE,
       created_at: OrderField.CREATED_AT,
+      createdAt: OrderField.CREATED_AT, //createdAt/craeted_at 혼용 대응
     };
     return map[value] || value;
   })

--- a/src/estimate-request/dto/estimate-request-pagination.dto.ts
+++ b/src/estimate-request/dto/estimate-request-pagination.dto.ts
@@ -23,7 +23,6 @@ export class EstimateRequestPaginationDto {
     const map = {
       move_date: OrderField.MOVE_DATE,
       created_at: OrderField.CREATED_AT,
-      createdAt: OrderField.CREATED_AT, //createdAt/craeted_at 혼용 대응
     };
     return map[value] || value;
   })

--- a/src/estimate-request/dto/estimate-request-pagination.dto.ts
+++ b/src/estimate-request/dto/estimate-request-pagination.dto.ts
@@ -1,0 +1,36 @@
+import { OrderField } from '@/common/dto/cursor-pagination.dto';
+import { Transform } from 'class-transformer';
+import { IsEnum, IsInt, IsOptional, IsString } from 'class-validator';
+/**
+ * EstimateRequestPaginationDto
+ *
+ * 기사 전용 견적 요청 목록 API에서 커서 기반 페이지네이션을 처리하기 위한 DTO
+ *
+ * - `cursor`: 현재 페이지의 마지막 요소를 기준으로 다음 데이터를 가져올 때 사용하는 커서 값
+ * - `orderField`: 정렬 기준 필드 (기본값: moveDate).
+ * - `take`: 가져올 데이터 개수 (기본값: 5)
+ *
+ *  `order` 필드나 `orderDirection`이 불필요해서 혼동을 줄이기 위해
+ *   해당 API에서 필요한 필드만 명시적으로 선언해서 사용하기 위해 CursorPaginationDto extends 하지 않음
+ *
+ */
+export class EstimateRequestPaginationDto {
+  @IsString()
+  @IsOptional()
+  cursor?: string;
+
+  @Transform(({ value }) => {
+    const map = {
+      move_date: OrderField.MOVE_DATE,
+      created_at: OrderField.CREATED_AT,
+    };
+    return map[value] || value;
+  })
+  @IsEnum(OrderField)
+  @IsOptional()
+  orderField?: OrderField = OrderField.MOVE_DATE;
+
+  @IsInt()
+  @IsOptional()
+  take?: number = 5;
+}

--- a/src/estimate-request/dto/estimate-request-response.dto.ts
+++ b/src/estimate-request/dto/estimate-request-response.dto.ts
@@ -16,7 +16,7 @@ export class EstimateRequestResponseDto {
 
   isTargeted?: boolean;
   customerName?: string;
-
+  offerCount: number; //받은 offer 개수 (request랑 offer 응답에서 구분하기 쉽게 추가했는데 필요없으면 제거 가능)
   estimateOffers: EstimateOfferResponseDto[];
 
   /**
@@ -28,7 +28,7 @@ export class EstimateRequestResponseDto {
    */
   static from(
     request: EstimateRequest,
-    offers?: EstimateOfferResponseDto[],
+    offers: EstimateOfferResponseDto[] = [],
     options?: {
       includeAddress?: boolean;
       includeMinimalAddress?: boolean;
@@ -41,10 +41,10 @@ export class EstimateRequestResponseDto {
     dto.createdAt = request.createdAt;
     dto.moveType = request.moveType;
     dto.moveDate = request.moveDate;
-    dto.estimateOffers = offers ?? [];
+    dto.estimateOffers = offers;
+    dto.offerCount = offers.length;
 
     dto.isTargeted = isTargeted ?? false;
-
     dto.customerName = request.customer?.user?.name ?? null;
 
     if (options?.includeAddress) {
@@ -54,12 +54,12 @@ export class EstimateRequestResponseDto {
 
     if (options?.includeMinimalAddress) {
       dto.fromAddressMinimal = {
-        sido: request.fromAddress.sido,
-        sigungu: request.fromAddress.sigungu,
+        sido: request.fromAddress?.sido,
+        sigungu: request.fromAddress?.sigungu,
       };
       dto.toAddressMinimal = {
-        sido: request.toAddress.sido,
-        sigungu: request.toAddress.sigungu,
+        sido: request.toAddress?.sido,
+        sigungu: request.toAddress?.sigungu,
       };
     }
 

--- a/src/estimate-request/dto/estimate-request-response.dto.ts
+++ b/src/estimate-request/dto/estimate-request-response.dto.ts
@@ -28,11 +28,12 @@ export class EstimateRequestResponseDto {
    */
   static from(
     request: EstimateRequest,
-    offers: EstimateOfferResponseDto[],
+    offers?: EstimateOfferResponseDto[],
     options?: {
       includeAddress?: boolean;
       includeMinimalAddress?: boolean;
     },
+    isTargeted?: boolean,
   ): EstimateRequestResponseDto {
     const dto = new EstimateRequestResponseDto();
 
@@ -40,11 +41,9 @@ export class EstimateRequestResponseDto {
     dto.createdAt = request.createdAt;
     dto.moveType = request.moveType;
     dto.moveDate = request.moveDate;
-    dto.estimateOffers = offers;
+    dto.estimateOffers = offers ?? [];
 
-    dto.isTargeted =
-      Array.isArray(request.targetMoverIds) &&
-      request.targetMoverIds.length > 0;
+    dto.isTargeted = isTargeted ?? false;
 
     dto.customerName = request.customer?.user?.name ?? null;
 

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -23,6 +23,7 @@ import { ApiGetRequestListForMover } from './docs/swagger';
 import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
 import { EstimateRequestResponseDto } from './dto/estimate-request-response.dto';
 import { GenericPaginatedDto } from '@/common/dto/paginated-response.dto';
+import { CreatedAtCursorPaginationDto } from '@/common/created-at-pagination.dto';
 
 @ApiBearerAuth()
 @Controller('estimate-request')
@@ -53,7 +54,7 @@ export class EstimateRequestController {
   @ApiGetMyEstimateHistory()
   async getHistory(
     @UserInfo() user: UserInfo,
-    @Query() pagination: EstimateRequestPaginationDto,
+    @Query() pagination: CreatedAtCursorPaginationDto,
   ): Promise<GenericPaginatedDto<EstimateRequestResponseDto>> {
     return this.estimateRequestService.findAllRequestHistoryWithPagination(
       user.sub,

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -68,6 +68,14 @@ export class EstimateRequestController {
       user.sub,
     );
   }
+
+  //Mover가 견적 요청 목록 조회
+  @Get('/')
+  @RBAC(Role.MOVER)
+  async getRequestListForMover(@UserInfo() user: UserInfo) {
+    return this.estimateRequestService.findRequestListForMover(user.sub);
+  }
+
   // @Delete(':id')
   // remove(@Param('id') id: string) {
   //   return this.estimateRequestService.remove(+id);

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -9,9 +9,6 @@ import {
 } from '@nestjs/common';
 import { EstimateRequestService } from './estimate-request.service';
 import { CreateEstimateRequestDto } from './dto/create-estimate-request.dto';
-
-// import { UpdateEstimateRequestDto } from './dto/update-estimate-request.dto';
-
 import { UserInfo } from '@/user/decorator/user-info.decorator';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { RBAC } from '@/auth/decorator/rbac.decorator';
@@ -22,6 +19,8 @@ import {
   ApiGetMyActiveEstimateRequest,
   ApiGetMyEstimateHistory,
 } from './docs/swagger';
+import { ApiGetRequestListForMover } from './docs/swagger';
+import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
 
 @ApiBearerAuth()
 @Controller('estimate-request')
@@ -72,8 +71,15 @@ export class EstimateRequestController {
   //Mover가 견적 요청 목록 조회
   @Get('/')
   @RBAC(Role.MOVER)
-  async getRequestListForMover(@UserInfo() user: UserInfo) {
-    return this.estimateRequestService.findRequestListForMover(user.sub);
+  @ApiGetRequestListForMover()
+  async getRequestListForMover(
+    @UserInfo() user: UserInfo,
+    @Query() pagination: EstimateRequestPaginationDto,
+  ) {
+    return this.estimateRequestService.findRequestListForMover(
+      user.sub,
+      pagination,
+    );
   }
 
   // @Delete(':id')

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -21,6 +21,8 @@ import {
 } from './docs/swagger';
 import { ApiGetRequestListForMover } from './docs/swagger';
 import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
+import { EstimateRequestResponseDto } from './dto/estimate-request-response.dto';
+import { GenericPaginatedDto } from '@/common/dto/paginated-response.dto';
 
 @ApiBearerAuth()
 @Controller('estimate-request')
@@ -46,11 +48,17 @@ export class EstimateRequestController {
     return this.estimateRequestService.create(dto, user);
   }
 
-  @Get('history')
+  @Get('/history')
   @RBAC(Role.CUSTOMER)
   @ApiGetMyEstimateHistory()
-  async findAllRequestHistory(@UserInfo() user: UserInfo) {
-    return this.estimateRequestService.findAllRequestHistory(user.sub);
+  async getHistory(
+    @UserInfo() user: UserInfo,
+    @Query() pagination: EstimateRequestPaginationDto,
+  ): Promise<GenericPaginatedDto<EstimateRequestResponseDto>> {
+    return this.estimateRequestService.findAllRequestHistoryWithPagination(
+      user.sub,
+      pagination,
+    );
   }
 
   @Patch(':requestId/targeted')

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -12,7 +12,7 @@ import {
   RequestStatus,
 } from './entities/estimate-request.entity';
 import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
-import { Brackets, DataSource, In, Repository } from 'typeorm';
+import { DataSource, In, Repository } from 'typeorm';
 import { UserInfo } from '@/user/decorator/user-info.decorator';
 
 import { EstimateOfferResponseDto } from '@/estimate-offer/dto/estimate-offer-response.dto';
@@ -21,7 +21,7 @@ import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
 
 import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
 import { GenericPaginatedDto } from '@/common/dto/paginated-response.dto';
-import { OrderDirection } from '@/common/dto/cursor-pagination.dto';
+import { EstimateOffer } from '@/estimate-offer/entities/estimate-offer.entity';
 @Injectable()
 export class EstimateRequestService {
   commonService: any;
@@ -109,63 +109,118 @@ export class EstimateRequestService {
   // COMPLETED, CANCELED, EXPIRED 상태만 조회 (대기, 진행 중인 요청 제외)
   validStatuses = ['CONFIRMED', 'COMPLETED', 'CANCELED', 'EXPIRED'];
 
-  async findAllRequestHistory(
+  async findAllRequestHistoryWithPagination(
     userId: string,
-  ): Promise<EstimateRequestResponseDto[]> {
-    const requests = await this.estimateRequestRepository.find({
-      where: {
-        status: In(this.validStatuses),
-      },
-      relations: [
-        'customer',
-        'customer.user',
-        'estimateOffers',
-        'estimateOffers.mover',
-        'estimateOffers.estimateRequest',
-        'estimateOffers.mover.reviews',
-        'estimateOffers.mover.likedCustomers',
-      ],
-      order: {
-        createdAt: 'DESC',
-      },
-    });
+    { cursor, take = 5 }: EstimateRequestPaginationDto,
+  ): Promise<GenericPaginatedDto<EstimateRequestResponseDto>> {
+    //기본 쿼리 빌더 구성: 고객이 생성한 견적 요청 + 관련 정보 join
+    const qb = this.estimateRequestRepository
+      .createQueryBuilder('request')
+      .addSelect('request.status') // dto에서 requestStatus 사용 시 명시적 select 필요
+      .leftJoinAndSelect('request.customer', 'customer')
+      .leftJoinAndSelect('customer.user', 'user')
+      .leftJoinAndSelect('request.estimateOffers', 'offer')
+      .leftJoinAndSelect('offer.mover', 'mover')
+      .leftJoinAndSelect('offer.estimateRequest', 'backRequest') // offer의 estimateRequest를 backRequest(alias임)로 조인
+      //TypeORM에서 양방향 관계일지라도, leftJoinAndSelect()를 통해 명시적으로 로드하지 않으면 undefined가 나올 수 있음
+      .leftJoinAndSelect('mover.reviews', 'reviews')
+      .leftJoinAndSelect('mover.likedCustomers', 'likedCustomers')
+      .where('user.id = :userId', { userId })
+      .andWhere('request.status IN (:...statuses)', {
+        statuses: this.validStatuses,
+      })
+      .orderBy('request.createdAt', 'DESC')
+      .take(take + 1); // hasNext 확인용 +1
+    // 커서 기반 페이지네이션 처리
+    // 클라이언트는 마지막 항목의 createdAt을 cursor로 전달함
+    // cursor 이전(createdAt < cursor)의 데이터만 조회하여 중복 없이 다음 페이지 구성
+    if (cursor) {
+      qb.andWhere('request.createdAt < :cursor', {
+        cursor: new Date(cursor),
+      });
+    }
+    // 데이터 조회 및 커서 페이징 처리
+    const requests = await qb.getMany();
+    const hasNext = requests.length > take;
+    const sliced = requests.slice(0, take);
 
-    const filtered = requests.filter(
-      (request) => request.customer.user.id === userId,
-    );
-
-    const allOfferMoverIds = filtered.flatMap((req) =>
+    const allMoverIds = sliced.flatMap((req) =>
       req.estimateOffers.map((o) => o.moverId),
     );
-
+    // offer에 대응하는 moverView 조회
     const moverViews = await this.dataSource
       .getRepository(MoverProfileView)
-      .findBy({ id: In(allOfferMoverIds) });
+      .findBy({ id: In(allMoverIds) });
 
     const moverViewMap = new Map(moverViews.map((v) => [v.id, v]));
 
-    return Promise.all(
-      filtered.map(async (request) => {
-        const offers = request.estimateOffers.map((offer) => {
-          const mover = offer.mover;
-          const isLiked = mover.likedCustomers?.some(
-            (like) => like?.customer?.user?.id === userId,
+    //  각 request에 포함된 offer 리스트 변환
+    const mapOffers = (
+      offers: EstimateOffer[],
+      viewMap: Map<string, MoverProfileView>,
+    ): EstimateOfferResponseDto[] => {
+      return offers.map((offer) => {
+        const mover = offer.mover;
+        const isLiked = mover.likedCustomers?.some(
+          (like) => like?.customer?.user?.id === userId,
+        );
+        const stats = viewMap.get(mover.id);
+        // 보장되지 않은 관계 확인
+        if (!offer.estimateRequest) {
+          throw new Error(
+            'EstimateOffer에서 estimateRequest가 로드되지 않았습니다.',
           );
-          const moverView = moverViewMap.get(mover.id);
-
-          return EstimateOfferResponseDto.from(offer, isLiked ?? false, {
-            confirmedCount: moverView?.confirmed_estimate_count ?? 0,
-            averageRating: moverView?.average_rating ?? 0,
-            reviewCount: moverView?.review_count ?? 0,
-            likeCount: moverView?.like_count ?? 0,
-            includeFullAddress: true,
-          });
+        }
+        if (!offer.mover) {
+          throw new Error('EstimateOffer에서 mover가 로드되지 않았습니다.');
+        }
+        return EstimateOfferResponseDto.from(offer, isLiked ?? false, {
+          confirmedCount: stats?.confirmed_estimate_count ?? 0,
+          averageRating: stats?.average_rating ?? 0,
+          reviewCount: stats?.review_count ?? 0,
+          likeCount: stats?.like_count ?? 0,
+          includeFullAddress: true,
         });
-
+      });
+    };
+    // 전체 응답 변환
+    const items = sliced.map((request, idx) => {
+      try {
+        const offers = mapOffers(request.estimateOffers, moverViewMap);
         return EstimateRequestResponseDto.from(request, offers);
-      }),
-    );
+      } catch (err) {
+        console.error(
+          '[ERROR] Failed on item index:',
+          idx,
+          'request:',
+          request,
+        );
+        throw err;
+      }
+    });
+    //  커서 생성
+    const nextCursor = hasNext
+      ? sliced[sliced.length - 1].createdAt.toISOString()
+      : null;
+
+    const totalCount = await this.estimateRequestRepository
+      .createQueryBuilder('request')
+      .leftJoin('request.customer', 'customer')
+      .leftJoin('customer.user', 'user')
+      .where('user.id = :userId', { userId })
+      .andWhere('request.status IN (:...statuses)', {
+        statuses: this.validStatuses,
+      })
+      .getCount();
+
+    return {
+      items,
+      hasNext,
+      nextCursor,
+      totalCount,
+    };
   }
+
   /**
    * 고객이 특정 견적 요청에 대해 기사를 지정
    * @param requestId 견적 요청 ID


### PR DESCRIPTION
## 🧚 변경사항 설명

- 고객이 받았던 견적 목록 조회하는 API에 커서페이지네이션 추가했습니다.
- 이전 PR 브랜치에서 생성한 브랜치라 커밋이 중복되어 뜨는데, f767e7172bc94efbc694300778ff13cfe2eb157e 이 커밋만 이 PR에 해당됩니다. 
- 이전 PR에서 추가했던 GenericPaginatedDto 재사용했습니다. 
- 페이지 UI상으로 한방향 정렬되고 정렬 필터는 따로 없어서, UX상 최근에 받았던것부터 ~ 과거 순으로 뜨는게 좋을 것 같아서 createdAt DSC 으로 정렬 적용했는데 수정이 필요하면 알려주세요. 
![image](https://github.com/user-attachments/assets/50dce146-dc0d-43e8-b122-cec102445d39)

## 🧑🏻‍🏫 To-do

- (대기중인)받은 견적 목록 조회 (고객) 커서 페이지네이션 적용

## 🎤 공유 사항

견적서 목록 중 확정된 것 처리하는 필터는 프론트에서 적용가능할 것 같아서 따로 로직 추가하지 않았는데, 백엔드 로직 추가가 필요하다면 알려주세요. 
<img width="545" alt="image" src="https://github.com/user-attachments/assets/1cf692c7-2ea7-45c6-b3f7-a89d439f1b66" />


## 🤙🏻 관련 이슈

Closes #67

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/359daf43-0a8c-48b2-a747-3863764182bc)
![image](https://github.com/user-attachments/assets/d85c45ff-5298-48fa-b045-b3211645e815)

