### PR TITLE
Feat/confirm estimate offer by customer

### DIFF
--- a/src/common/decorator/query-runner.decorator.ts
+++ b/src/common/decorator/query-runner.decorator.ts
@@ -1,0 +1,19 @@
+import {
+  createParamDecorator,
+  ExecutionContext,
+  InternalServerErrorException,
+} from '@nestjs/common';
+
+import type { QueryRunner as QR } from 'typeorm';
+
+export const QueryRunner = createParamDecorator(
+  (_: unknown, context: ExecutionContext): QR => {
+    const req = context.switchToHttp().getRequest();
+
+    if (!req || !req.queryRunner) {
+      throw new InternalServerErrorException('QueryRunner를 찾을 수 없습니다!');
+    }
+
+    return req.queryRunner as QR;
+  },
+);

--- a/src/common/docs/response.swagger.ts
+++ b/src/common/docs/response.swagger.ts
@@ -82,6 +82,27 @@ export const CODE_401_RESPONSES = {
   },
 };
 
+// 403
+export const CODE_403_FORBIDDEN = (errorExamples: ErrorExample[]) => {
+  return {
+    status: 403,
+    description: '권한 없음',
+    content: {
+      'application/json': {
+        examples: Object.fromEntries(
+          errorExamples.map((example) => [
+            example.key,
+            {
+              summary: example.summary,
+              value: example.value,
+            },
+          ]),
+        ),
+      },
+    },
+  };
+};
+
 // 404
 export const CODE_404_NOT_FOUND = (errorExamples: ErrorExample[]) => {
   return {

--- a/src/common/docs/validation.swagger.ts
+++ b/src/common/docs/validation.swagger.ts
@@ -221,7 +221,38 @@ export const unsupportedSocialLoginError = {
   },
 };
 
-//404
+export const estimateRequestAlreadyProcessedError = {
+  key: 'estimateRequestAlreadyProcessedError',
+  summary: '이미 처리된 견적 요청인 경우',
+  value: {
+    statusCode: 400,
+    message: '이미 처리된 견적 요청입니다.',
+    error: 'Bad Request',
+  },
+};
+
+export const estimateOfferAlreadyProcessedError = {
+  key: 'estimateOfferAlreadyProcessedError',
+  summary: '이미 처리된 견적 제안인 경우',
+  value: {
+    statusCode: 400,
+    message: '이미 처리된 견적 제안입니다.',
+    error: 'Bad Request',
+  },
+};
+
+// 403
+export const ForbiddenError = {
+  key: 'ForbiddenError',
+  summary: '접근 권한 없음',
+  value: {
+    statusCode: 403,
+    message: '접근 권한이 없습니다.',
+    error: 'Forbidden',
+  },
+};
+
+// 404
 export const moverNotFoundError = {
   key: 'moverNotFoundError',
   summary: '기사님을 찾을 수 없는 경우',
@@ -258,6 +289,26 @@ export const moverProfileNotFoundError = {
   value: {
     statusCode: 404,
     message: '[mover] 프로필을 찾을 수 없습니다.',
+    error: 'Not Found',
+  },
+};
+
+export const estimateRequestNotFoundError = {
+  key: 'estimateRequestNotFoundError',
+  summary: '견적 요청을 찾을 수 없는 경우',
+  value: {
+    statusCode: 404,
+    message: '견적 요청을 찾을 수 없습니다.',
+    error: 'Not Found',
+  },
+};
+
+export const estimateOfferNotFoundError = {
+  key: 'estimateOfferNotFoundError',
+  summary: '견적 제안을 찾을 수 없는 경우',
+  value: {
+    statusCode: 404,
+    message: '해당 견적 제안을 찾을 수 없습니다.',
     error: 'Not Found',
   },
 };

--- a/src/common/dto/cursor-pagination.dto.ts
+++ b/src/common/dto/cursor-pagination.dto.ts
@@ -25,7 +25,8 @@ export class CursorPaginationDto {
   cursor?: string;
 
   @IsObject()
-  order: OrderItemMap;
+  @IsOptional()
+  order?: OrderItemMap;
 
   @IsInt()
   @IsOptional()

--- a/src/estimate-offer/docs/swagger.ts
+++ b/src/estimate-offer/docs/swagger.ts
@@ -7,12 +7,24 @@ import {
   ApiResponse,
 } from '@nestjs/swagger';
 import {
+  CODE_200_SUCCESS,
   CODE_400_BAD_REQUEST,
   CODE_401_RESPONSES,
+  CODE_403_FORBIDDEN,
+  CODE_404_NOT_FOUND,
+  CODE_500_INTERNAL_SERVER_ERROR,
 } from '@/common/docs/response.swagger';
 import { EstimateOfferResponseDto } from '../dto/estimate-offer-response.dto';
 import { CreateEstimateOfferDto } from '../dto/create-estimate-offer.dto';
 import { UpdateEstimateOfferDto } from '../dto/update-estimate-offer.dto';
+import { MessageSchema } from '@/common/docs/schema.swagger';
+import {
+  estimateOfferAlreadyProcessedError,
+  estimateOfferNotFoundError,
+  estimateRequestAlreadyProcessedError,
+  estimateRequestNotFoundError,
+  ForbiddenError,
+} from '@/common/docs/validation.swagger';
 
 export function ApiGetPendingEstimateOffers() {
   return applyDecorators(
@@ -164,5 +176,55 @@ export function ApiRejectEstimateOffer() {
       description: '견적 요청을 찾을 수 없음 또는 권한 없음',
     }),
     ApiResponse(CODE_401_RESPONSES),
+  );
+}
+
+export function ApiConfirmEstimateOffer() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '견적 요청 확정',
+      description: '고객이 기사에게 받은 견적을 확정합니다.',
+    }),
+    ApiBearerAuth(),
+    ApiParam({
+      name: 'requestId',
+      required: true,
+      description: '견적 요청 ID (UUID)',
+      example: '9ed4f4a0-0391-4a4f-af22-039aed8ccc9b',
+      type: String,
+    }),
+    ApiParam({
+      name: 'moverId',
+      required: true,
+      description: '기사 ID (UUID)',
+      example: '1a2b3c4d-5678-90ef-abcd-1234567890ab',
+      type: String,
+    }),
+    ApiResponse(
+      CODE_200_SUCCESS({
+        description: '견적 요청 확정 성공한 경우',
+        schema: MessageSchema('견적 제안이 성공적으로 확정되었습니다.'),
+      }),
+    ),
+    ApiResponse(
+      CODE_400_BAD_REQUEST([
+        estimateRequestAlreadyProcessedError,
+        estimateOfferAlreadyProcessedError,
+      ]),
+    ),
+    ApiResponse(CODE_403_FORBIDDEN([ForbiddenError])),
+    ApiResponse(CODE_401_RESPONSES),
+    ApiResponse(
+      CODE_404_NOT_FOUND([
+        estimateRequestNotFoundError,
+        estimateOfferNotFoundError,
+      ]),
+    ),
+    ApiResponse(
+      CODE_500_INTERNAL_SERVER_ERROR({
+        description: '견적 요청 확정 실패한 경우',
+        message: '견적 확정 처리 중 서버 오류가 발생했습니다.',
+      }),
+    ),
   );
 }

--- a/src/estimate-offer/estimate-offer.controller.ts
+++ b/src/estimate-offer/estimate-offer.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiGetPendingEstimateOffers,
   ApiCreateEstimateOffer,
   ApiRejectEstimateOffer,
+  ApiConfirmEstimateOffer,
 } from './docs/swagger';
 import { ApiBearerAuth } from '@nestjs/swagger';
 import { RBAC } from '@/auth/decorator/rbac.decorator';
@@ -107,6 +108,7 @@ export class EstimateOfferController {
   @Patch(':requestId/:moverId/confirmed')
   @RBAC(Role.CUSTOMER)
   @UseInterceptors(TransactionInterceptor)
+  @ApiConfirmEstimateOffer()
   async confirmOffer(
     @Param('requestId') requestId: string,
     @Param('moverId') moverId: string,

--- a/src/mover-profile/mover-profile.service.ts
+++ b/src/mover-profile/mover-profile.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Injectable,
   InternalServerErrorException,
   NotFoundException,
@@ -60,10 +61,16 @@ export class MoverProfileService {
   }
 
   async findAll(user: UserInfo, dto: GetMoverProfilesDto) {
-    const { serviceType, serviceRegion } = dto;
+    const { serviceType, serviceRegion, order } = dto;
     const { sub: userId, role } = user;
     const isCustomer = role === Role.CUSTOMER;
     let targetMoverIds: string[] = [];
+
+    if (!order) {
+      throw new BadRequestException(
+        "정렬 기준이 필요합니다. 'order' 필드를 포함해주세요.",
+      );
+    }
 
     // 집계 필드 정렬시: MoverProfile을 베이스로 하고 뷰와 조인
     const qb = this.moverProfileRepository


### PR DESCRIPTION
## 🧚 변경사항 설명

- 고객의 제안한 견적 확정 API
- 커서기반 페이지 네이션 DTO 리팩토링 (order 속성 optional로 리팩토링)

## 🧑🏻‍🏫 To-do

- 커서기반 페이지 네이션 DTO를 사용하여 리팩토링 진행 필요

## 🎤 공유 사항

- 트랜잭션 사용을 위한 @queryRunner 데코레이터를 사용하시면 됩니다.

```ts
// 고객이 기사의 제안 견적 확정
  @Patch(':requestId/:moverId/confirmed')
  @RBAC(Role.CUSTOMER)
  @UseInterceptors(TransactionInterceptor) // 트랜잭션 사용을 위한 인터셉터
  @ApiConfirmEstimateOffer()
  async confirmOffer(
    @Param('requestId') requestId: string,
    @Param('moverId') moverId: string,
    @UserInfo() userInfo: UserInfo,
    @QueryRunner() queryRunner: QR, // 트랜잭션 인터셉터에서 지정한 request.queryRunner를 받아오는 데코레이터
  ) {
    return await handleError(
      () =>
        this.estimateOfferService.confirm(
          requestId,
          moverId,
          userInfo.sub,
          queryRunner,
        ),
      '견적 확정 처리 중 서버 오류가 발생했습니다.',
    );
  }
```

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

<!-- 기능 완성 PR의 경우 UI 변경사항, API 호출 테스트 결과 등의 스크린샷을 첨부해주세요 -->
