### PR TITLE
moverId -> moverProfileId 로 수정 

### DIFF
--- a/src/estimate-offer/docs/swagger.ts
+++ b/src/estimate-offer/docs/swagger.ts
@@ -127,7 +127,7 @@ export function ApiGetEstimateOfferDetail() {
       type: String,
     }),
     ApiParam({
-      name: 'moverId',
+      name: 'moverProfileId',
       description: '기사 ID (UUID)',
       example: '9ec9e7ba-d922-48b4-a821-17842bc02944',
       type: String,
@@ -249,7 +249,7 @@ export function ApiConfirmEstimateOffer() {
       type: String,
     }),
     ApiParam({
-      name: 'moverId',
+      name: 'moverProfileId',
       required: true,
       description: '기사 ID (UUID)',
       example: '1a2b3c4d-5678-90ef-abcd-1234567890ab',

--- a/src/estimate-offer/estimate-offer.controller.ts
+++ b/src/estimate-offer/estimate-offer.controller.ts
@@ -52,12 +52,12 @@ export class EstimateOfferController {
   }
 
   // 견적 요청 ID와 기사 ID로 견적 제안 상세 조회
-  @Get(':requestId/:moverId/pending')
+  @Get(':requestId/:moverProfileId/pending')
   @RBAC(Role.CUSTOMER)
   @ApiGetEstimateOfferDetail()
   async getOfferDetail(
     @Param('requestId') requestId: string,
-    @Param('moverId') moverId: string,
+    @Param('moverProfileId') moverId: string,
     @UserInfo() userInfo: UserInfo,
   ) {
     return this.estimateOfferService.findOneByCompositeKey(

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -162,14 +162,14 @@ export function ApiAddTargetMover() {
       schema: {
         type: 'object',
         properties: {
-          moverId: {
+          moverProfileId: {
             type: 'string',
             format: 'uuid',
             example: '9ec9e7ba-d922-48b4-a821-17842bc02944',
-            description: '추가할 기사님 ID (MoverId)',
+            description: '추가할 기사님 ID (moverProfileId)',
           },
         },
-        required: ['moverId'],
+        required: ['moverProfileId'],
       },
     }),
     ApiResponse({
@@ -232,7 +232,6 @@ export function ApiGetRequestListForMover() {
       description:
         '이후 응답에서 받은 `nextCursor` 값을 사용해 다음 페이지를 조회하세요.',
     }),
-
     ApiQuery({
       name: 'take',
       required: false,
@@ -240,15 +239,12 @@ export function ApiGetRequestListForMover() {
       example: 5,
     }),
 
-    // 추가된 부분
     ApiExtraModels(GenericPaginatedDto, EstimateRequestResponseDto),
     ApiOkResponse({
       description: '견적 요청 목록 조회 성공',
       schema: {
         allOf: [
-          {
-            $ref: getSchemaPath(GenericPaginatedDto),
-          },
+          { $ref: getSchemaPath(GenericPaginatedDto) },
           {
             properties: {
               items: {


### PR DESCRIPTION
## 🧚 변경사항 설명
- moverId -> moverProfileId 로 수정 
- 스웨거 문서만 수정했더니 문서와 실제 코드의 파라미터 이름의 불일치로 스웨거 문서에 moverId, moverProfileId 두개가 떠서 경로, 파람, 스웨거 일치시켰습니다. 

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

<!-- 기타 팀원들이 참고해야 할 사항이 있으면 작성해주세요  -->

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/b6974939-f8a4-430c-a609-006c0ee351fe)
![image](https://github.com/user-attachments/assets/e276071f-7d1b-41d3-9d04-235acde38ba1)

