### PR TITLE
Fix/견적요청 생성, 지정견적기사 추가 API 

### DIFF
--- a/src/estimate-request/dto/create-estimate-request.dto.ts
+++ b/src/estimate-request/dto/create-estimate-request.dto.ts
@@ -6,6 +6,7 @@ import {
   ValidateNested,
   IsOptional,
   IsArray,
+  IsUUID,
 } from 'class-validator';
 import { ServiceType } from '@/common/const/service.const';
 
@@ -43,5 +44,6 @@ export class CreateEstimateRequestDto {
 
   @IsOptional()
   @IsArray()
+  @IsUUID('all', { each: true }) // UUID 형식 검증 추가
   targetMoverIds?: string[];
 }

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -67,12 +67,12 @@ export class EstimateRequestController {
   @ApiAddTargetMover()
   async addTargetedMover(
     @Param('requestId') estimateRequestId: string,
-    @Body() body: { moverId: string },
+    @Body() body: { moverProfileId: string },
     @UserInfo() user: UserInfo,
   ) {
     return this.estimateRequestService.addTargetMover(
       estimateRequestId,
-      body.moverId,
+      body.moverProfileId,
       user.sub,
     );
   }

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -90,6 +90,7 @@ export class EstimateRequestService {
       moveDate: new Date(dto.moveDate),
       fromAddress: dto.fromAddress,
       toAddress: dto.toAddress,
+      targetMoverIds: dto.targetMoverIds,
       customer,
     });
 
@@ -215,7 +216,7 @@ export class EstimateRequestService {
    */
   async addTargetMover(
     requestId: string,
-    moverId: string, // MoverProfile.id
+    moverProfileId: string, // MoverProfile.id
     userId: string,
   ): Promise<{ message: string }> {
     const request = await this.estimateRequestRepository.findOne({
@@ -227,9 +228,10 @@ export class EstimateRequestService {
     if (request.customer.user.id !== userId)
       throw new ForbiddenException('해당 요청에 접근할 수 없습니다.');
 
-    const currentIds = request.targetMoverIds || [];
+    const currentIds =
+      request.targetMoverIds?.filter((id): id is string => !!id) || [];
 
-    if (currentIds.includes(moverId)) {
+    if (currentIds.includes(moverProfileId)) {
       throw new BadRequestException('이미 지정 기사로 추가된 기사입니다.');
     }
 
@@ -240,14 +242,14 @@ export class EstimateRequestService {
     }
 
     const mover = await this.moverProfileRepository.findOne({
-      where: { id: moverId },
+      where: { id: moverProfileId },
     });
 
     if (!mover) {
       throw new NotFoundException('해당 기사님의 프로필을 찾을 수 없습니다.');
     }
 
-    request.targetMoverIds = [...currentIds, moverId];
+    request.targetMoverIds = [...currentIds, moverProfileId];
     await this.estimateRequestRepository.save(request);
 
     return {


### PR DESCRIPTION
## 🧚 변경사항 설명

- 견적 요청 생성시 dto에 targetmoverId 누락되어 추가
- 지정 견적기사 추가시 moverId -> moverProfileId로 수정하여 targetMoverIds 배열에 잘 저장되는 것 확인

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #31 , #53

## 📸 스크린샷

![image](https://github.com/user-attachments/assets/44bb9019-d4e9-4eb0-bbac-5d49ede89d38)
