### PR TITLE
Fix/고객이 받은 견적 상세 조회 에러 해결

### DIFF
--- a/src/customer-profile/customer-profile.module.ts
+++ b/src/customer-profile/customer-profile.module.ts
@@ -14,6 +14,6 @@ import { UserModule } from '@/user/user.module';
   ],
   controllers: [CustomerProfileController],
   providers: [CustomerProfileService],
-  exports: [CustomerProfileService],
+  exports: [CustomerProfileService, TypeOrmModule],
 })
 export class CustomerProfileModule {}

--- a/src/estimate-offer/estimate-offer.module.ts
+++ b/src/estimate-offer/estimate-offer.module.ts
@@ -5,10 +5,16 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { EstimateOffer } from './entities/estimate-offer.entity';
 import { EstimateRequest } from '@/estimate-request/entities/estimate-request.entity';
 import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
+import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([EstimateOffer, EstimateRequest, MoverProfile]),
+    TypeOrmModule.forFeature([
+      EstimateOffer,
+      EstimateRequest,
+      MoverProfile,
+      CustomerProfile,
+    ]),
   ],
   controllers: [EstimateOfferController],
   providers: [EstimateOfferService],

--- a/src/estimate-offer/estimate-offer.service.ts
+++ b/src/estimate-offer/estimate-offer.service.ts
@@ -24,6 +24,7 @@ import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
 import { OrderField } from '@/common/validator/order.validator';
 import { GenericPaginatedDto } from '@/common/dto/paginated-response.dto';
 import { CreatedAtCursorPaginationDto } from '../common/dto/created-at-pagination.dto';
+import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
 
 @Injectable()
 export class EstimateOfferService {
@@ -32,6 +33,8 @@ export class EstimateOfferService {
     private readonly offerRepository: Repository<EstimateOffer>,
     @InjectRepository(EstimateRequest)
     private readonly requestRepository: Repository<EstimateRequest>,
+    @InjectRepository(CustomerProfile)
+    private readonly customerProfileRepository: Repository<CustomerProfile>,
     @InjectRepository(MoverProfile)
     private readonly moverRepository: Repository<MoverProfile>,
     private readonly dataSource: DataSource,
@@ -241,6 +244,7 @@ export class EstimateOfferService {
   }
 
   /**
+   * 고객이 받은 견적 상세 조회
    * 견적 요청ID에 대한 오퍼 중 특정 기사 오퍼 상세 조회
    */
   async findOneByCompositeKey(
@@ -253,6 +257,7 @@ export class EstimateOfferService {
       relations: [
         'mover',
         'mover.likedCustomers',
+        'mover.likedCustomers.customer',
         'estimateRequest',
         'estimateRequest.customer',
         'estimateRequest.customer.user',
@@ -278,8 +283,14 @@ export class EstimateOfferService {
       ],
     });
 
+    const customerId = (
+      await this.customerProfileRepository.findOne({
+        where: { user: { id: userId } },
+      })
+    )?.id;
+
     const isLiked = offer.mover.likedCustomers?.some(
-      (like) => like.customer.id === userId,
+      (like) => like.customer?.id === customerId,
     );
 
     const dto = EstimateOfferResponseDto.from(offer, isLiked ?? false, {

--- a/src/estimate-offer/estimate-offer.service.ts
+++ b/src/estimate-offer/estimate-offer.service.ts
@@ -283,14 +283,14 @@ export class EstimateOfferService {
       ],
     });
 
-    const customerId = (
+    const customerProfileId = (
       await this.customerProfileRepository.findOne({
         where: { user: { id: userId } },
       })
     )?.id;
 
     const isLiked = offer.mover.likedCustomers?.some(
-      (like) => like.customer?.id === customerId,
+      (like) => like.customer?.id === customerProfileId,
     );
 
     const dto = EstimateOfferResponseDto.from(offer, isLiked ?? false, {


### PR DESCRIPTION
## 🧚 변경사항 설명
- 고객이 받은 견적 상세 조회 에러 해결
- isLiked 응답 가져올때, 자신의 프로필Id가 likedCustomers 배열에 있는지 확인하는 로직인데, customerProfile레포지토리 주입없이 userId를 직접 Like.customer.id와 비교하면서 undefined 에러 예외처리가 되지 않아서 에러 발생하여 userId → customerProfile.id를 조회하여 likedCustomers.customer.id === customerId로 비교하도록 수정

## 🎤 공유 사항

<!-- 기타 팀원들이 참고해야 할 사항이 있으면 작성해주세요  -->

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

<!-- 기능 완성 PR의 경우 UI 변경사항, API 호출 테스트 결과 등의 스크린샷을 첨부해주세요 -->
