### PR TITLE
Fix/받았던 견적 목록, 대기중인 받은 견적 목록 조회 수정 외

### DIFF
--- a/src/estimate-offer/dto/estimate-offer-response.dto.ts
+++ b/src/estimate-offer/dto/estimate-offer-response.dto.ts
@@ -2,6 +2,7 @@ import { AddressDto } from '@/common/dto/address.dto';
 import { EstimateOffer } from '../entities/estimate-offer.entity';
 
 export class EstimateOfferResponseDto {
+  offerId: string;
   estimateRequestId: string;
   moverId: string;
   price: number;
@@ -20,6 +21,7 @@ export class EstimateOfferResponseDto {
   toAddressMinimal?: { sido: string; sigungu: string };
 
   mover: {
+    moverId: string;
     nickname: string;
     imageUrl?: string;
     experience: number;
@@ -44,12 +46,12 @@ export class EstimateOfferResponseDto {
     },
   ): EstimateOfferResponseDto {
     const dto = new EstimateOfferResponseDto();
-
-    dto.estimateRequestId = offer.estimateRequestId;
-    dto.moverId = offer.moverId;
+    dto.offerId = offer.id;
+    // dto.estimateRequestId = offer.estimateRequestId;
+    // dto.moverId = offer.moverId;
     dto.price = offer.price;
     dto.status = offer.status;
-    dto.requestStatus = offer.estimateRequest.status;
+    // dto.requestStatus = offer.estimateRequest.status;
     dto.isTargeted = !!offer.estimateRequest.targetMoverIds?.includes(
       offer.moverId,
     );
@@ -76,6 +78,7 @@ export class EstimateOfferResponseDto {
     }
 
     dto.mover = {
+      moverId: offer.moverId,
       nickname: offer.mover.nickname,
       imageUrl: offer.mover.imageUrl,
       experience: offer.mover.experience,

--- a/src/estimate-offer/dto/estimate-offer-response.dto.ts
+++ b/src/estimate-offer/dto/estimate-offer-response.dto.ts
@@ -6,7 +6,7 @@ export class EstimateOfferResponseDto {
   estimateRequestId: string;
   moverId: string;
   price: number;
-  status: string;
+  offerStatus: string;
   requestStatus: string;
   isTargeted: boolean;
   isConfirmed: boolean;
@@ -47,11 +47,11 @@ export class EstimateOfferResponseDto {
   ): EstimateOfferResponseDto {
     const dto = new EstimateOfferResponseDto();
     dto.offerId = offer.id;
-    // dto.estimateRequestId = offer.estimateRequestId;
-    // dto.moverId = offer.moverId;
+    dto.estimateRequestId = offer.estimateRequestId;
+    dto.moverId = offer.moverId;
     dto.price = offer.price;
-    dto.status = offer.status;
-    // dto.requestStatus = offer.estimateRequest.status;
+    dto.offerStatus = offer.status;
+    dto.requestStatus = offer.estimateRequest.status;
     dto.isTargeted = !!offer.estimateRequest.targetMoverIds?.includes(
       offer.moverId,
     );

--- a/src/estimate-offer/estimate-offer.controller.ts
+++ b/src/estimate-offer/estimate-offer.controller.ts
@@ -144,7 +144,7 @@ export class EstimateOfferController {
   @ApiConfirmEstimateOffer()
   async confirmOffer(
     @Param('requestId') requestId: string,
-    @Param('moverId') moverId: string,
+    @Param('moverProfileId') moverId: string,
     @UserInfo() userInfo: UserInfo,
     @QueryRunner() queryRunner: QR,
   ) {

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -81,7 +81,7 @@ export function ApiGetMyEstimateHistory() {
     ApiOperation({
       summary: '받았던 견적 목록 조회',
       description:
-        '고객이 생성한 견적 요청 중 완료(COMPLETED), 취소(CANCELED), 만료(EXPIRED)된 요청 목록에 대해 받았던 견적서 목록을 커서 기반 페이지네이션 방식으로 조회합니다.\n정렬 기준은 생성일 최신 순(`createdAt DESC`)으로 고정되어 있습니다.',
+        '고객이 생성한 견적 요청 중 확정(CONFIRMED), 완료(COMPLETED),  만료(EXPIRED)된 요청 목록에 대해 받았던 견적서 목록을 커서 기반 페이지네이션 방식으로 조회합니다.\n정렬 기준은 생성일 최신 순(`createdAt DESC`)으로 고정되어 있습니다.',
     }),
     ApiBearerAuth(),
 
@@ -90,7 +90,6 @@ export function ApiGetMyEstimateHistory() {
       required: false,
       description:
         '커서 기준 값. 응답의 `nextCursor` 값을 복사해 다음 요청에 사용하세요.',
-      example: '2025-06-15T12:00:00.000Z',
     }),
     ApiQuery({
       name: 'take',

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -126,20 +126,36 @@ export function ApiGetMyEstimateHistory() {
 export function ApiGetMyActiveEstimateRequest() {
   return applyDecorators(
     ApiOperation({
-      summary: '진행 중인 견적 요청 ID 조회 (개발용)',
-      description: 'PENDING, CONFIRMED 상태의 견적 요청 ID만 반환합니다.',
+      summary: '진행 중인 견적 요청 ID 조회',
+      description: 'PENDING 상태의 견적 요청 ID만 반환합니다.',
     }),
     ApiResponse({
       status: 200,
-      description: '진행 중인 estimateRequestId 리스트',
+      description: '진행 중인 견적 요청이 없을 경우 메시지를 반환합니다.',
       schema: {
-        type: 'array',
-        items: {
-          type: 'object',
-          properties: {
-            estimateRequestId: { type: 'string', example: 'uuid-example' },
+        oneOf: [
+          {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                estimateRequestId: {
+                  type: 'string',
+                  example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                },
+              },
+            },
           },
-        },
+          {
+            type: 'object',
+            properties: {
+              message: {
+                type: 'string',
+                example: '현재 진행중인 견적 요청이 없습니다.',
+              },
+            },
+          },
+        ],
       },
     }),
   );

--- a/src/estimate-request/dto/estimate-request-response.dto.ts
+++ b/src/estimate-request/dto/estimate-request-response.dto.ts
@@ -4,7 +4,8 @@ import { EstimateOfferResponseDto } from '@/estimate-offer/dto/estimate-offer-re
 import { EstimateRequest } from '../entities/estimate-request.entity';
 
 export class EstimateRequestResponseDto {
-  id: string;
+  requestId: string;
+  requestStatus: EstimateRequest['status']; // 견적 요청 상태 (PENDING, CONFIRMED, REJECTED, COMPLETED, CANCELED, EXPIRED)
   createdAt: Date;
   moveType: ServiceType;
   moveDate: Date;
@@ -37,13 +38,13 @@ export class EstimateRequestResponseDto {
   ): EstimateRequestResponseDto {
     const dto = new EstimateRequestResponseDto();
 
-    dto.id = request.id;
+    dto.requestId = request.id;
+    dto.requestStatus = request.status;
     dto.createdAt = request.createdAt;
     dto.moveType = request.moveType;
     dto.moveDate = request.moveDate;
     dto.estimateOffers = offers;
     dto.offerCount = offers.length;
-
     dto.isTargeted = isTargeted ?? false;
     dto.customerName = request.customer?.user?.name ?? null;
 

--- a/src/estimate-request/entities/estimate-request.entity.ts
+++ b/src/estimate-request/entities/estimate-request.entity.ts
@@ -23,7 +23,7 @@ export type Address = {
 export enum RequestStatus {
   PENDING = 'PENDING', // 견적 제안 대기 중
   CONFIRMED = 'CONFIRMED', // 고객이 기사님 1명 확정
-  REJECTED = 'REJECTED', // 기사님이 반려함
+  REJECTED = 'REJECTED', // 기사님이 반려함 //TODO: 이거 offerStatus랑 양쪽에 있는거 맞을까요?
   COMPLETED = 'COMPLETED', // 이사 완료
   CANCELED = 'CANCELED', // 고객이 요청 취소
   EXPIRED = 'EXPIRED', // 이사일 지나도록 확정 없음

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -47,18 +47,20 @@ export class EstimateRequestService {
    */
   async findActiveEstimateRequestIds(
     userId: string,
-  ): Promise<{ estimateRequestId: string }[]> {
-    return this.estimateRequestRepository
-      .find({
-        where: {
-          customer: { user: { id: userId } },
-          status: In([RequestStatus.PENDING, RequestStatus.CONFIRMED]),
-        },
-        select: { id: true }, // `id`만 반환
-      })
-      .then((requests) =>
-        requests.map((req) => ({ estimateRequestId: req.id })),
-      );
+  ): Promise<{ message: string } | { estimateRequestId: string }[]> {
+    const requests = await this.estimateRequestRepository.find({
+      where: {
+        customer: { user: { id: userId } },
+        status: RequestStatus.PENDING,
+      },
+      select: { id: true },
+    });
+
+    if (requests.length === 0) {
+      return { message: '현재 진행중인 견적 요청이 없습니다.' };
+    }
+
+    return requests.map((req) => ({ estimateRequestId: req.id }));
   }
   /**
    * 견적 요청 생성

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -114,17 +114,21 @@ export class EstimateRequestService {
    * @param userId 고객 ID
    * @returns EstimateRequestResponseDto[]
    */
-  // COMPLETED, CANCELED, EXPIRED 상태만 조회 (대기, 진행 중인 요청 제외)
+  // CONFIRMED, COMPLETED, EXPIRED 상태만 조회 (대기중인 요청 제외)
   validStatuses = ['CONFIRMED', 'COMPLETED', 'EXPIRED'];
-
   async findAllRequestHistoryWithPagination(
     userId: string,
     { cursor, take = 5 }: CreatedAtCursorPaginationDto,
   ): Promise<GenericPaginatedDto<EstimateRequestResponseDto>> {
-    //기본 쿼리 빌더 구성: 고객이 생성한 견적 요청 + 관련 정보 join
+    const [cursorDatePart, cursorIdPart] = cursor?.split('|') ?? [];
+    const cursorValue = cursorDatePart ? new Date(cursorDatePart) : undefined;
+    if (cursorValue && isNaN(cursorValue.getTime())) {
+      throw new BadRequestException('유효하지 않은 커서 값입니다.');
+    }
+
     const qb = this.estimateRequestRepository
       .createQueryBuilder('request')
-      .addSelect('request.status') // dto에서 requestStatus 사용 시 명시적 select 필요
+      .addSelect('request.status')
       .leftJoinAndSelect('request.customer', 'customer')
       .leftJoinAndSelect('customer.user', 'user')
       .leftJoinAndSelect('request.estimateOffers', 'offer')
@@ -138,16 +142,28 @@ export class EstimateRequestService {
         statuses: this.validStatuses,
       })
       .orderBy('request.createdAt', 'DESC')
-      .take(take + 1); // hasNext 확인용 +1
-    // 커서 기반 페이지네이션 처리
-    // 클라이언트는 마지막 항목의 createdAt을 cursor로 전달함
-    // cursor 이전(createdAt < cursor)의 데이터만 조회하여 중복 없이 다음 페이지 구성
-    if (cursor) {
-      qb.andWhere('request.createdAt < :cursor', {
-        cursor: new Date(cursor),
-      });
+      .addOrderBy('request.id', 'DESC')
+      .take(take + 1);
+
+    if (cursorValue) {
+      qb.andWhere(
+        new Brackets((qb) => {
+          qb.where('request.createdAt < :cursorValue', { cursorValue });
+          if (cursorIdPart) {
+            qb.orWhere(
+              new Brackets((qb2) => {
+                qb2
+                  .where('request.createdAt = :cursorValue', { cursorValue })
+                  .andWhere('request.id < :cursorId', {
+                    cursorId: cursorIdPart,
+                  });
+              }),
+            );
+          }
+        }),
+      );
     }
-    // 데이터 조회 및 커서 페이징 처리
+
     const requests = await qb.getMany();
     const hasNext = requests.length > take;
     const sliced = requests.slice(0, take);
@@ -155,14 +171,12 @@ export class EstimateRequestService {
     const allMoverIds = sliced.flatMap((req) =>
       req.estimateOffers.map((o) => o.moverId),
     );
-    // offer에 대응하는 moverView 조회
     const moverViews = await this.dataSource
       .getRepository(MoverProfileView)
       .findBy({ id: In(allMoverIds) });
 
     const moverViewMap = new Map(moverViews.map((v) => [v.id, v]));
 
-    //  각 request에 포함된 offer 리스트 변환
     const mapOffers = (
       offers: EstimateOffer[],
       viewMap: Map<string, MoverProfileView>,
@@ -189,10 +203,9 @@ export class EstimateRequestService {
       return EstimateRequestResponseDto.from(request, offers);
     });
 
-    //  커서 생성
-    const nextCursor = hasNext
-      ? sliced[sliced.length - 1].createdAt.toISOString()
-      : null;
+    const last = sliced[sliced.length - 1];
+    const nextCursor =
+      hasNext && last ? `${last.createdAt.toISOString()}|${last.id}` : null;
 
     const totalCount = await this.estimateRequestRepository
       .createQueryBuilder('request')


### PR DESCRIPTION
## 🧚 변경사항 설명

- 테스트중 오류 있거나 개선할 부분들 수정했습니다.
- 진행중인 견적 요청 ID Pending 상태인 것만 뜨도록 수정, 없을 경우 빈배열 말고 메시지 반환 처리
- 견적요청 확정 API param moverId -> moverProfileId로 수정
- history(받았던 견적 목록), pending (요청에 받은 offer 목록) 조회 커서 페이지네이션 복합커서(createdAt+ id) 적용 
  - createdAt으로만 했더니 동시에 생성된 경우 문제 발생해서 수정
- offerId dto에 추가하여 응답값에 반영

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

- API 응답값에 offerId 추가되는 등 수정된 형태 노션 백엔드 api 명세서 페이지에 업데이트해두었습니다. 

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

<!-- 기능 완성 PR의 경우 UI 변경사항, API 호출 테스트 결과 등의 스크린샷을 첨부해주세요 -->
