### PR TITLE
Refactor/전체기사님조회

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,9 +50,6 @@ importers:
       '@sentry/node':
         specifier: ^9.28.0
         version: 9.28.1
-      '@types/web-push':
-        specifier: ^3.6.4
-        version: 3.6.4
       axios:
         specifier: ^1.9.0
         version: 1.9.0
@@ -1859,9 +1856,6 @@ packages:
 
   '@types/validator@13.15.1':
     resolution: {integrity: sha512-9gG6ogYcoI2mCMLdcO0NYI0AYrbxIjv0MDmy/5Ywo6CpWWrqYayc+mmgxRsCgtcGJm9BSbXkMsmxGah1iGHAAQ==}
-
-  '@types/web-push@3.6.4':
-    resolution: {integrity: sha512-GnJmSr40H3RAnj0s34FNTcJi1hmWFV5KXugE0mYWnYhgTAHLJ/dJKAwDmvPJYMke0RplY2XE9LnM4hqSqKIjhQ==}
 
   '@types/yargs-parser@21.0.3':
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
@@ -6891,10 +6885,6 @@ snapshots:
       '@types/node': 22.15.31
 
   '@types/validator@13.15.1': {}
-
-  '@types/web-push@3.6.4':
-    dependencies:
-      '@types/node': 22.15.31
 
   '@types/yargs-parser@21.0.3': {}
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -99,6 +99,7 @@ export class AppModule implements NestModule {
         { path: 'auth/login', method: RequestMethod.POST }, /// 로컬 로그인 제외
         { path: 'auth/login/:social', method: RequestMethod.GET }, /// 모든 소셜 로그인 (:social 매개변수 사용) 제외
         { path: 'auth/callback/:social', method: RequestMethod.GET }, /// 모든 소셜 콜백 (:social 매개변수 사용) 제외
+        { path: 'auth/logout', method: RequestMethod.POST }, /// 로그아웃 제외
       )
       .forRoutes('*'); /// 모든 라우트에 미들웨어 적용
   }

--- a/src/common/common.service.ts
+++ b/src/common/common.service.ts
@@ -49,7 +49,6 @@ export class CommonService {
         values: Record<string, any>;
         order: OrderString;
       };
-      console.log('request cursorObj: ', cursorObj);
 
       const { values } = cursorObj;
       order = cursorObj.order; // cursorObj에서 order 추출
@@ -57,12 +56,8 @@ export class CommonService {
       const { field, direction } = parseOrderString(order);
 
       const orderAlias = this.getOrderFieldAlias(qb, field);
-      console.log('orderAlias: ', orderAlias);
       const cursorId = values.id;
-      console.log('cursorId: ', cursorId);
       const cursorValue = parseFloat(values[field]);
-      console.log('cursorValue: ', cursorValue);
-      console.log('typeof cursorValue: ', typeof cursorValue);
 
       const operator = direction === OrderDirection.DESC ? '<' : '>';
       const whereClause = `(${orderAlias} ${operator} :cursorValue OR (${orderAlias} = :cursorValue AND ${qb.alias}.id < :cursorId))`;
@@ -76,12 +71,10 @@ export class CommonService {
     }
 
     const orderAlias = this.getOrderFieldAlias(qb, field);
-    console.log('orderAlias: ', orderAlias);
 
     qb.addOrderBy(orderAlias, direction); // 정렬 기준 필드
     qb.addOrderBy(`${qb.alias}.id`, OrderDirection.DESC); // 항상 id도 정렬에 포함
 
-    console.log('FULL SQL:', qb.getQueryAndParameters());
     /**
      * Q) qb.addOrderBy(`${qb.alias}.id`, direction); 이거 왜 해용 ?.?
      * A) 정렬 기준 값이 동일할 때, 중복 제거 및 페이지네이션 정확도를 위한 보조 정렬로서,
@@ -115,14 +108,10 @@ export class CommonService {
 
     // join은 어차피 계속 될거라서 그냥 배열에 있는 값이랑 OrderField랑 있는지 비교해서 있으면 true로 변경하기
 
-    console.log('results: ', results);
     const lastItem = results.at(-1);
-    console.log('lastItem: ', lastItem);
     const { field } = parseOrderString(order);
     const isStatsField = MoverStatsField.includes(field);
-    console.log('field: ', field);
     const value = isStatsField ? lastItem[statsAlias][field] : lastItem[field];
-    console.log('value: ', value);
 
     if (!value) {
       throw new BadRequestException(
@@ -138,7 +127,6 @@ export class CommonService {
       },
       order,
     };
-    console.log('cursorObj: ', cursorObj);
 
     const nextCursor = Buffer.from(JSON.stringify(cursorObj)).toString(
       'base64',

--- a/src/common/const/query-builder.const.ts
+++ b/src/common/const/query-builder.const.ts
@@ -1,19 +1,26 @@
-export const MOVER_PROFILE_TABLE = 'mover_profile'; // mover profile 쿼리 빌더 별칭
-export const MOVER_PROFILE_VIEW_TABLE = 'mover_profile_view'; // mover profile view 쿼리 빌더 별칭
+export const MOVER_TABLE = 'mover_profile'; // mover profile 쿼리 빌더 별칭
+export const MOVER_VIEW_TABLE = 'mover_profile_view'; // mover view name
 
-export const MOVER_PROFILE_LIST_SELECT = [
-  `${MOVER_PROFILE_TABLE}.id`,
-  `${MOVER_PROFILE_TABLE}.nickname`,
-  `${MOVER_PROFILE_TABLE}.imageUrl`,
-  `${MOVER_PROFILE_TABLE}.experience`,
-  `${MOVER_PROFILE_TABLE}.intro`,
-  `${MOVER_PROFILE_TABLE}.serviceType`,
+// 별칭 사용하여 select문 정의
+export const MOVER_LIST_SELECT = [
+  `${MOVER_TABLE}.id`,
+  `${MOVER_TABLE}.nickname`,
+  `${MOVER_TABLE}.imageUrl`,
+  `${MOVER_TABLE}.experience`,
+  `${MOVER_TABLE}.serviceType`,
+  `${MOVER_TABLE}.intro`,
+];
+export const MOVER_LIST_STATS_SELECT = [
+  `stats.review_count`,
+  `stats.average_rating`,
+  `stats.confirmed_estimate_count`,
+  `stats.like_count`,
 ];
 
 export const LIKED_MOVER_LIST_SELECT = [
-  `${MOVER_PROFILE_TABLE}.id`,
-  `${MOVER_PROFILE_TABLE}.nickname`,
-  `${MOVER_PROFILE_TABLE}.imageUrl`,
-  `${MOVER_PROFILE_TABLE}.experience`,
-  `${MOVER_PROFILE_TABLE}.serviceType`,
+  `${MOVER_TABLE}.id`,
+  `${MOVER_TABLE}.nickname`,
+  `${MOVER_TABLE}.imageUrl`,
+  `${MOVER_TABLE}.experience`,
+  `${MOVER_TABLE}.serviceType`,
 ];

--- a/src/common/const/query-builder.const.ts
+++ b/src/common/const/query-builder.const.ts
@@ -17,6 +17,17 @@ export const MOVER_LIST_STATS_SELECT = [
   `stats.like_count`,
 ];
 
+export const MOVER_PROFILE_SELECT = [
+  `${MOVER_TABLE}.id`,
+  `${MOVER_TABLE}.nickname`,
+  `${MOVER_TABLE}.imageUrl`,
+  `${MOVER_TABLE}.experience`,
+  `${MOVER_TABLE}.intro`,
+  `${MOVER_TABLE}.description`,
+  `${MOVER_TABLE}.serviceType`,
+  `${MOVER_TABLE}.serviceRegion`,
+];
+
 export const LIKED_MOVER_LIST_SELECT = [
   `${MOVER_TABLE}.id`,
   `${MOVER_TABLE}.nickname`,

--- a/src/common/docs/schema.swagger.ts
+++ b/src/common/docs/schema.swagger.ts
@@ -37,20 +37,26 @@ export const MoverProfileListSchema = {
   example: {
     movers: [
       {
-        id: 'c9844fd7-d5f5-455c-8e11-f73ac3cfb9df',
-        nickname: '무빙이',
+        id: 'f888f633-2c37-4e39-a898-a4a288d39355',
+        nickname: '기사님6',
         imageUrl: 'https://example.com/image.jpg',
         experience: 5,
         intro: '친절한 이사 전문가입니다.',
-        description: '고객님의 이사를 정성껏 도와드립니다.',
-        serviceType: defaultServiceType,
-        serviceRegion: defaultServiceRegion,
+        serviceType: {
+          SMALL: true,
+          HOME: true,
+          OFFICE: true,
+        },
+        review_count: 0,
+        average_rating: 0,
+        confirmed_estimate_count: 1,
+        like_count: 1,
+        isTargeted: false,
       },
     ],
-    count: 1,
+    hasNext: true,
     nextCursor:
       'eyJ2YWx1ZXMiOnsiaWQiOiJjOTg0NGZkNy1kNWY1LTQ1NWMtOGUxMS1mNzNhYzNjZmI5ZGYifSwib3JkZXIiOnsiZmllbGQiOiJjb25maXJtZWRfZXN0aW1hdGVfY291bnQiLCJkaXJlY3Rpb24iOiJERVNDIn19',
-    hasNext: true,
   },
 };
 

--- a/src/common/docs/schema.swagger.ts
+++ b/src/common/docs/schema.swagger.ts
@@ -52,6 +52,7 @@ export const MoverProfileListSchema = {
         confirmed_estimate_count: 1,
         like_count: 1,
         isTargeted: false,
+        isLiked: false,
       },
     ],
     hasNext: true,

--- a/src/common/docs/schema.swagger.ts
+++ b/src/common/docs/schema.swagger.ts
@@ -62,25 +62,42 @@ export const MoverProfileListSchema = {
 
 export const MoverProfileDetailSchema = {
   example: {
-    id: '8a12f8b9-1e4b-49f2-8302-4c5c8cbcb488',
-    nickname: '최강이사',
+    id: 'f888f633-2c37-4e39-a898-a4a288d39355',
+    nickname: '기사님6',
+    imageUrl: 'https://example.com/image.jpg',
     experience: 5,
-    averageRating: 4.8,
-    reviewCount: 10,
-    confirmedEstimateCount: 15,
-    like_count: 21,
-    reviews: [
-      {
-        rating: 5,
-        comment: '정말 친절하셨어요!',
-        createdAt: '2025-05-01T12:34:56.000Z',
-        customer: {
-          user: {
-            email: 'customer@example.com',
-          },
-        },
-      },
-    ],
+    intro: '친절한 이사 전문가입니다.',
+    description: '고객님의 이사를 정성껏 도와드립니다.',
+    serviceType: {
+      SMALL: true,
+      HOME: true,
+      OFFICE: true,
+    },
+    serviceRegion: {
+      Seoul: true,
+      'Gyeonggi-do': true,
+      Incheon: true,
+      'Gangwon-do': true,
+      'Chungcheongbuk-do': true,
+      'Chungcheongnam-do': true,
+      'Sejong-si': true,
+      Daejeon: true,
+      'Jeonbuk-do': true,
+      'Jeollanam-do': true,
+      Gwangju: true,
+      'Gyeongsangbuk-do': true,
+      'Gyeongsangnam-do': true,
+      Daegu: true,
+      Ulsan: true,
+      Busan: true,
+      'Jeju-do': true,
+    },
+    reviewCount: 0,
+    averageRating: 0,
+    confirmedEstimateCount: 1,
+    likeCount: 1,
+    isTargeted: false,
+    isLiked: false,
   },
 };
 

--- a/src/common/utils/handle-error.util.ts
+++ b/src/common/utils/handle-error.util.ts
@@ -6,7 +6,8 @@ export async function handleError<T>(
 ): Promise<T> {
   try {
     return await fn();
-  } catch (_error) {
+  } catch (error) {
+    console.error(error); // 또는 로깅 서비스 호출
     throw new InternalServerErrorException(errorMessage);
   }
 }

--- a/src/common/validator/order.validator.ts
+++ b/src/common/validator/order.validator.ts
@@ -8,11 +8,20 @@ export enum OrderField {
   // string 맵핑 값에 무조건 소문자로 정의 postgreSQL에서 소문자만 인식함
   REVIEW_COUNT = 'review_count', // 리뷰 수
   AVERAGE_RATING = 'average_rating', // 평균 평점
-  EXPERIENCE = 'experience', // 경력
   CONFIRMED_ESTIMATE_COUNT = 'confirmed_estimate_count', // 확정 견적 수
+  LIKE_COUNT = 'like_count', // 좋아요 수
+
+  EXPERIENCE = 'experience', // 경력
   CREATED_AT = 'created_at', // 생성일 DESC 최신순
   MOVE_DATE = 'move_date', // 이사 날짜
 }
+
+export const MoverStatsField = [
+  OrderField.REVIEW_COUNT,
+  OrderField.AVERAGE_RATING,
+  OrderField.CONFIRMED_ESTIMATE_COUNT,
+  OrderField.LIKE_COUNT,
+];
 
 export enum OrderDirection {
   ASC = 'ASC', // 오름차순

--- a/src/customer-profile/customer-profile.helper.ts
+++ b/src/customer-profile/customer-profile.helper.ts
@@ -1,0 +1,44 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { CustomerProfile } from './entities/customer-profile.entity';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class CustomerProfileHelper {
+  constructor(
+    @InjectRepository(CustomerProfile)
+    private readonly customerProfileRepository: Repository<CustomerProfile>,
+  ) {}
+
+  public async getCustomerId(userId: string) {
+    const customer = await this.customerProfileRepository.findOne({
+      where: { user: { id: userId } },
+      select: ['id'],
+    });
+
+    if (!customer) {
+      throw new NotFoundException(
+        '고객님의 프로필을 찾을 수 없습니다, 프로필을 생성해주세요!',
+      );
+    }
+
+    return customer.id;
+  }
+
+  public async getLikedMoverIds(customerId: string) {
+    const customer = await this.customerProfileRepository.findOne({
+      where: { id: customerId },
+      relations: ['likedMovers', 'likedMovers.mover'],
+    });
+
+    if (!customer) {
+      throw new NotFoundException('고객님의 프로필을 찾을 수 없습니다!');
+    }
+
+    const likedMovers = customer.likedMovers;
+
+    return likedMovers
+      .map((like) => like.mover.id)
+      .filter((id): id is string => typeof id === 'string');
+  }
+}

--- a/src/customer-profile/customer-profile.module.ts
+++ b/src/customer-profile/customer-profile.module.ts
@@ -5,6 +5,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CommonModule } from '@/common/common.module';
 import { CustomerProfile } from './entities/customer-profile.entity';
 import { UserModule } from '@/user/user.module';
+import { CustomerProfileHelper } from './customer-profile.helper';
 
 @Module({
   imports: [
@@ -13,7 +14,7 @@ import { UserModule } from '@/user/user.module';
     CommonModule,
   ],
   controllers: [CustomerProfileController],
-  providers: [CustomerProfileService],
-  exports: [CustomerProfileService, TypeOrmModule],
+  providers: [CustomerProfileService, CustomerProfileHelper],
+  exports: [CustomerProfileService, CustomerProfileHelper, TypeOrmModule],
 })
 export class CustomerProfileModule {}

--- a/src/customer-profile/customer-profile.service.ts
+++ b/src/customer-profile/customer-profile.service.ts
@@ -16,6 +16,7 @@ export class CustomerProfileService {
   constructor(
     @InjectRepository(CustomerProfile)
     private readonly customerProfileRepository: Repository<CustomerProfile>,
+
     private readonly userService: UserService,
   ) {}
 
@@ -91,20 +92,5 @@ export class CustomerProfileService {
     return {
       message: '고객님의 프로필이 성공적으로 업데이트되었습니다.',
     };
-  }
-
-  public async getCustomerId(userId: string) {
-    const customer = await this.customerProfileRepository.findOne({
-      where: { user: { id: userId } },
-      select: ['id'],
-    });
-
-    if (!customer) {
-      throw new NotFoundException(
-        '고객님의 프로필을 찾을 수 없습니다, 프로필을 생성해주세요!',
-      );
-    }
-
-    return customer.id;
   }
 }

--- a/src/estimate-offer/estimate-offer.service.ts
+++ b/src/estimate-offer/estimate-offer.service.ts
@@ -209,7 +209,7 @@ export class EstimateOfferService {
           OrderField.CONFIRMED_ESTIMATE_COUNT,
           OrderField.REVIEW_COUNT,
           OrderField.AVERAGE_RATING,
-          'like_count',
+          OrderField.LIKE_COUNT,
         ],
       });
     const moverViewMap = new Map(moverViews.map((view) => [view.id, view])); // 빠르게 해당 moverId의 view 데이터를 찾기 위해서

--- a/src/estimate-request/estimate-request.service.ts
+++ b/src/estimate-request/estimate-request.service.ts
@@ -351,4 +351,20 @@ export class EstimateRequestService {
       totalCount,
     };
   }
+
+  public async getTargetMoverIds(customerId: string) {
+    const estimateRequest = await this.estimateRequestRepository.findOne({
+      where: {
+        customer: { id: customerId },
+        status: RequestStatus.PENDING,
+      },
+      select: ['targetMoverIds'], // 필요한 필드만 가져오기
+    });
+
+    if (!estimateRequest) {
+      throw new NotFoundException('지정 견적 요청을 찾을 수 없습니다.');
+    }
+
+    return estimateRequest?.targetMoverIds || [];
+  }
 }

--- a/src/like/like.service.ts
+++ b/src/like/like.service.ts
@@ -5,8 +5,8 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Like } from './entities/like.entity';
 import {
   LIKED_MOVER_LIST_SELECT,
-  MOVER_PROFILE_TABLE,
-  MOVER_PROFILE_VIEW_TABLE,
+  MOVER_TABLE,
+  MOVER_VIEW_TABLE,
 } from '@/common/const/query-builder.const';
 import { MoverProfileView } from '@/mover-profile/view/mover-profile.view';
 import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
@@ -60,15 +60,15 @@ export class LikeService {
 
     // 찜한 기사님이 있는 경우
     const qb = this.moverProfileRepository
-      .createQueryBuilder(MOVER_PROFILE_TABLE)
+      .createQueryBuilder(MOVER_TABLE)
       .select(LIKED_MOVER_LIST_SELECT) // entity select
       .leftJoinAndSelect(
         MoverProfileView,
-        MOVER_PROFILE_VIEW_TABLE,
-        `${MOVER_PROFILE_TABLE}.id = ${MOVER_PROFILE_VIEW_TABLE}.id`,
+        MOVER_VIEW_TABLE,
+        `${MOVER_TABLE}.id = ${MOVER_VIEW_TABLE}.id`,
       )
-      .where(`${MOVER_PROFILE_TABLE}.id IN (:...ids)`, { ids: likedMoverIds })
-      .orderBy(`${MOVER_PROFILE_VIEW_TABLE}.like_count`, 'DESC');
+      .where(`${MOVER_TABLE}.id IN (:...ids)`, { ids: likedMoverIds })
+      .orderBy(`${MOVER_TABLE}.like_count`, 'DESC');
 
     const { entities, raw: aggregates } = await qb.getRawAndEntities();
 

--- a/src/like/like.service.ts
+++ b/src/like/like.service.ts
@@ -12,7 +12,7 @@ import { MoverProfileView } from '@/mover-profile/view/mover-profile.view';
 import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
 import { MoverProfileService } from '@/mover-profile/mover-profile.service';
 import { handleError } from '@/common/utils/handle-error.util';
-import { CustomerProfileService } from '@/customer-profile/customer-profile.service';
+import { CustomerProfileHelper } from '@/customer-profile/customer-profile.helper';
 
 @Injectable()
 export class LikeService {
@@ -25,11 +25,11 @@ export class LikeService {
     private readonly moverProfileRepository: Repository<MoverProfile>,
 
     private readonly moverProfileService: MoverProfileService,
-    private readonly customerProfileService: CustomerProfileService,
+    private readonly customerProfileHelper: CustomerProfileHelper,
   ) {}
 
   async create(userId: string, moverId: string) {
-    const customerId = await this.customerProfileService.getCustomerId(userId); // 고객 ID 가져오기
+    const customerId = await this.customerProfileHelper.getCustomerId(userId); // 고객 ID 가져오기
     const moverNickname = await this.checkMoverExists(moverId); // 기사 존재 여부 확인 후 별명 가져오기
 
     await handleError(
@@ -41,7 +41,7 @@ export class LikeService {
   }
 
   async findAll(userId: string) {
-    const customerId = await this.customerProfileService.getCustomerId(userId);
+    const customerId = await this.customerProfileHelper.getCustomerId(userId);
 
     const customer = await this.customerProfileRepository.findOne({
       where: { id: customerId },
@@ -79,7 +79,7 @@ export class LikeService {
   }
 
   async remove(userId: string, moverId: string) {
-    const customerId = await this.customerProfileService.getCustomerId(userId); // 고객 ID 가져오기
+    const customerId = await this.customerProfileHelper.getCustomerId(userId); // 고객 ID 가져오기
     const moverNickname = await this.checkMoverExists(moverId); // 기사 존재 여부 확인 후 별명 가져오기
 
     await handleError(

--- a/src/mover-profile/docs/swagger.ts
+++ b/src/mover-profile/docs/swagger.ts
@@ -20,7 +20,6 @@ import {
   MessageSchema,
   MoverProfileDetailSchema,
   MoverProfileListSchema,
-  MoverProfileSchema,
 } from '@/common/docs/schema.swagger';
 import {
   CreateMoverProfileFullExample,
@@ -67,7 +66,7 @@ export const ApiCreateMoverProfile = () =>
     ApiResponse(
       CODE_201_CREATED({
         description: '[mover] 프로필 생성 성공',
-        schema: MoverProfileSchema,
+        schema: MessageSchema('기사님의 프로필이 성공적으로 생성되었습니다.'),
       }),
     ),
     ApiResponse(
@@ -105,7 +104,7 @@ export function ApiUpdateMyMoverProfile() {
     ApiResponse(
       CODE_200_SUCCESS({
         description: '본인의 [mover] 프로필 수정 성공한 경우',
-        schema: MessageSchema('[mover] 프로필이 성공적으로 수정되었습니다.'),
+        schema: MessageSchema('기사님의 프로필이 성공적으로 수정되었습니다.'),
       }),
     ),
     ApiResponse(

--- a/src/mover-profile/entities/mover-profile.entity.ts
+++ b/src/mover-profile/entities/mover-profile.entity.ts
@@ -11,11 +11,11 @@ import {
 import { Like } from 'src/like/entities/like.entity';
 import { EstimateOffer } from 'src/estimate-offer/entities/estimate-offer.entity';
 import { Review } from 'src/review/entities/review.entity';
-import { MOVER_PROFILE_TABLE } from '@/common/const/query-builder.const';
 import { ServiceRegionMap, ServiceTypeMap } from '@/common/const/service.const';
 import { BaseTable } from '@/common/entity/base-table.entity';
+import { MoverProfileView } from '../view/mover-profile.view';
 
-@Entity(MOVER_PROFILE_TABLE)
+@Entity()
 export class MoverProfile extends BaseTable {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -58,4 +58,8 @@ export class MoverProfile extends BaseTable {
   // moverProfile : Review <-> 1:N 관계
   @OneToMany(() => Review, (review) => review.mover)
   reviews: Review[];
+
+  // MoverProfile : MoverProfileView <-> 1:1 관계
+  @OneToOne(() => MoverProfileView, (view) => view.moverProfile)
+  stats: MoverProfileView;
 }

--- a/src/mover-profile/mover-profile.controller.ts
+++ b/src/mover-profile/mover-profile.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiGetMyMoverProfile,
   ApiUpdateMyMoverProfile,
 } from './docs/swagger';
+import { handleError } from '@/common/utils/handle-error.util';
 
 @Controller('mover')
 @RBAC(Role.MOVER) // mover만 접근 가능, customer은 접근 불가
@@ -34,27 +35,40 @@ export class MoverProfileController {
     @Body() createMoverProfileDto: CreateMoverProfileDto,
     @UserInfo() userInfo: UserInfo,
   ) {
-    return this.moverProfileService.create(userInfo.sub, createMoverProfileDto);
+    return handleError(
+      () =>
+        this.moverProfileService.create(userInfo.sub, createMoverProfileDto),
+      '기사님의 프로필 생성 중 서버에 오류가 생겨 실패했습니다, 다시 시도해주세요!',
+    );
   }
 
   @Get()
   @Public()
   @ApiGetMoverProfiles()
   findAll(@UserInfo() userInfo: UserInfo, @Query() dto: GetMoverProfilesDto) {
-    return this.moverProfileService.findAll(userInfo, dto);
+    return handleError(
+      () => this.moverProfileService.findAll(userInfo, dto),
+      '기사님 프로필 목록 조회 중 서버에 오류가 생겨 실패했습니다, 다시 시도해주세요!',
+    );
   }
 
   @Get('me')
   @ApiGetMyMoverProfile()
   findMe(@UserInfo() userInfo: UserInfo) {
-    return this.moverProfileService.findMe(userInfo.sub);
+    return handleError(
+      () => this.moverProfileService.findMe(userInfo.sub),
+      '기사님 프로필 조회 중 서버에 오류가 생겨 실패했습니다, 다시 시도해주세요!',
+    );
   }
 
   @Get(':id')
   @Public()
   @ApiGetMoverProfileById()
-  findOne(@Param('id') id: string) {
-    return this.moverProfileService.findOne(id);
+  findOne(@UserInfo() userInfo: UserInfo, @Param('id') id: string) {
+    return handleError(
+      () => this.moverProfileService.findOne(userInfo, id),
+      '기사님 프로필 조회 중 서버에 오류가 생겨 실패했습니다, 다시 시도해주세요!',
+    );
   }
 
   @Patch('me')
@@ -63,6 +77,10 @@ export class MoverProfileController {
     @UserInfo() userInfo: UserInfo,
     @Body() updateMoverProfileDto: UpdateMoverProfileDto,
   ) {
-    return this.moverProfileService.update(userInfo.sub, updateMoverProfileDto);
+    return handleError(
+      () =>
+        this.moverProfileService.update(userInfo.sub, updateMoverProfileDto),
+      '기사님의 프로필 수정 중 서버에 오류가 생겨 실패했습니다, 다시 시도해주세요!',
+    );
   }
 }

--- a/src/mover-profile/mover-profile.helper.ts
+++ b/src/mover-profile/mover-profile.helper.ts
@@ -1,0 +1,68 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { MoverProfile } from './entities/mover-profile.entity';
+import { Repository } from 'typeorm';
+import { camelCase } from 'lodash';
+import { OrderField } from '@/common/validator/order.validator';
+// import { MoverProfileView } from './view/mover-profile.view';
+// import { MOVER_VIEW_TABLE } from '@/common/const/query-builder.const';
+import { EstimateRequestService } from '@/estimate-request/estimate-request.service';
+import { CustomerProfileHelper } from '@/customer-profile/customer-profile.helper';
+
+@Injectable()
+export class MoverProfileHelper {
+  constructor(
+    @InjectRepository(MoverProfile)
+    private readonly moverProfileRepository: Repository<MoverProfile>,
+
+    private readonly customerProfileHelper: CustomerProfileHelper,
+    private readonly estimateRequestService: EstimateRequestService,
+  ) {}
+
+  public async getMoverId(userId: string) {
+    const mover = await this.moverProfileRepository.findOne({
+      where: { user: { id: userId } },
+      select: ['id'],
+    });
+
+    if (!mover) {
+      throw new NotFoundException(
+        '기사님의 프로필을 찾을 수 없습니다, 프로필을 생성해주세요!',
+      );
+    }
+
+    return mover.id;
+  }
+
+  public mergeMoverProfileWithAggregates(profile: MoverProfile) {
+    const { stats, ...rest } = profile;
+
+    return {
+      ...rest,
+      [camelCase(OrderField.REVIEW_COUNT)]: Number(stats.review_count),
+      [camelCase(OrderField.AVERAGE_RATING)]:
+        Math.round(Number(stats.average_rating) * 10) / 10,
+      [camelCase(OrderField.CONFIRMED_ESTIMATE_COUNT)]: Number(
+        stats.confirmed_estimate_count,
+      ),
+      [camelCase(OrderField.LIKE_COUNT)]: Number(stats.like_count),
+    };
+  }
+
+  public async getCustomerRelatedMoverIds(userId: string, isCustomer: boolean) {
+    // 고객이 아닌 경우, 빈 배열 반환
+    if (!isCustomer) {
+      return { targetMoverIds: [], likedMoverIds: [] };
+    }
+
+    // 고객인 경우
+    const customerId = await this.customerProfileHelper.getCustomerId(userId);
+
+    const targetMoverIds =
+      await this.estimateRequestService.getTargetMoverIds(customerId); // 견적 요청 대상 기사 IDs
+    const likedMoverIds =
+      await this.customerProfileHelper.getLikedMoverIds(customerId); // 좋아요한 기사 IDs
+
+    return { targetMoverIds, likedMoverIds };
+  }
+}

--- a/src/mover-profile/mover-profile.module.ts
+++ b/src/mover-profile/mover-profile.module.ts
@@ -8,6 +8,7 @@ import { CommonModule } from 'src/common/common.module';
 import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
 import { EstimateRequest } from '@/estimate-request/entities/estimate-request.entity';
 import { Review } from '@/review/entities/review.entity';
+import { CustomerProfileModule } from '@/customer-profile/customer-profile.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { Review } from '@/review/entities/review.entity';
       Review,
     ]),
     CommonModule,
+    CustomerProfileModule,
   ],
   controllers: [MoverProfileController],
   providers: [MoverProfileService],

--- a/src/mover-profile/mover-profile.module.ts
+++ b/src/mover-profile/mover-profile.module.ts
@@ -3,27 +3,20 @@ import { MoverProfileService } from './mover-profile.service';
 import { MoverProfileController } from './mover-profile.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { MoverProfile } from './entities/mover-profile.entity';
-import { MoverProfileView } from './view/mover-profile.view';
 import { CommonModule } from 'src/common/common.module';
-import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
-import { EstimateRequest } from '@/estimate-request/entities/estimate-request.entity';
-import { Review } from '@/review/entities/review.entity';
 import { CustomerProfileModule } from '@/customer-profile/customer-profile.module';
+import { EstimateRequestModule } from '@/estimate-request/estimate-request.module';
+import { MoverProfileHelper } from './mover-profile.helper';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([
-      MoverProfile,
-      MoverProfileView,
-      CustomerProfile,
-      EstimateRequest,
-      Review,
-    ]),
+    TypeOrmModule.forFeature([MoverProfile]),
     CommonModule,
     CustomerProfileModule,
+    EstimateRequestModule,
   ],
   controllers: [MoverProfileController],
-  providers: [MoverProfileService],
-  exports: [MoverProfileService, TypeOrmModule],
+  providers: [MoverProfileService, MoverProfileHelper],
+  exports: [MoverProfileService, MoverProfileHelper, TypeOrmModule],
 })
 export class MoverProfileModule {}

--- a/src/review/review.controller.ts
+++ b/src/review/review.controller.ts
@@ -6,14 +6,15 @@ import { handleError } from '@/common/utils/handle-error.util';
 import { Role } from '@/user/entities/user.entity';
 import { RBAC } from '@/auth/decorator/rbac.decorator';
 import { PagePaginationDto } from '@/common/dto/page-pagination.dto';
-import { CustomerProfileService } from '@/customer-profile/customer-profile.service';
+
 import { Public } from '@/auth/decorator/public.decorator';
+import { CustomerProfileHelper } from '@/customer-profile/customer-profile.helper';
 
 @Controller('review')
 export class ReviewController {
   constructor(
     private readonly reviewService: ReviewService,
-    private readonly customerProfileService: CustomerProfileService,
+    private readonly customerProfileHelper: CustomerProfileHelper,
   ) {}
 
   @Post(':confirmedOfferId')
@@ -52,7 +53,7 @@ export class ReviewController {
     @UserInfo() userInfo: UserInfo,
     @Query() dto: PagePaginationDto,
   ) {
-    const customerId = await this.customerProfileService.getCustomerId(
+    const customerId = await this.customerProfileHelper.getCustomerId(
       userInfo.sub,
     );
 

--- a/src/review/review.service.ts
+++ b/src/review/review.service.ts
@@ -14,7 +14,7 @@ import {
 } from '@/estimate-request/entities/estimate-request.entity';
 import { PagePaginationDto } from '@/common/dto/page-pagination.dto';
 import { CommonService } from '@/common/common.service';
-import { CustomerProfileService } from '@/customer-profile/customer-profile.service';
+import { CustomerProfileHelper } from '@/customer-profile/customer-profile.helper';
 
 @Injectable()
 export class ReviewService {
@@ -27,7 +27,7 @@ export class ReviewService {
     private readonly estimateOfferRepository: Repository<EstimateOffer>,
 
     private readonly commonService: CommonService,
-    private readonly customerProfileService: CustomerProfileService,
+    private readonly customerProfileHelper: CustomerProfileHelper,
   ) {}
 
   /**
@@ -46,7 +46,7 @@ export class ReviewService {
     createReviewDto: CreateReviewDto,
   ) {
     // 1. 사용자 ID로 고객 ID를 추출
-    const customerId = await this.customerProfileService.getCustomerId(userId);
+    const customerId = await this.customerProfileHelper.getCustomerId(userId);
 
     // 2. 견적 제안 ID로 해당 견적 제안을 조회
     const offer = await this.estimateOfferRepository.findOne({


### PR DESCRIPTION
## 🧚 변경사항 설명

- [ae72aa8](https://github.com/FS05-PART4-TEAM1/5-moving-team1-be/pull/88/commits/ae72aa864dbb2d12c9828cd0f5ee3aef966b86a5): mover 서비스에 있던 reposnse를 반환하지 않는 함수들 helper함수로 분리

- [06ac413](https://github.com/FS05-PART4-TEAM1/5-moving-team1-be/pull/88/commits/06ac413c843bfc7a179381897fcfcc32a07d698b): customer 서비스에 있던 reposnse를 반환하지 않는 함수들 helper함수로 분리

## 🧑🏻‍🏫 To-do

- 전체 기사님 조회 커서기반 페이지네이션

- 기사님 프로필 상세 및 본인 기사 프로필 조회

- 기사님 프로필 swagger 리팩토링

## 🎤 공유 사항

- 1:1 관계 설정
MoverStatsView와 MoverProfile 엔티티 간에 1:1 관계를 추가했습니다.
목적: 커서 기반 페이지네이션에서 take를 적용한 getMany() 사용 시, 집계 필드(stats)를 함께 조회하기 위함입니다.
배경: 관계가 없을 경우 getRawMany()로는 집계 필드를 가져올 수 있으나, take가 제대로 적용되지 않아 커서 페이지네이션에 문제가 발생했습니다.

- 서비스 로직 분리
customer, mover 서비스 내 응답을 반환하지 않는 내부 로직 함수들을 별도의 helper 함수로 분리했습니다.
현재는 본인만 사용하는 함수들로, 다른 서비스와 겹치지 않습니다.

- 고객 전용 플래그 추가
기사님 전체 목록 조회 및 기사 프로필 상세 조회 응답에 고객일 경우 아래 플래그를 추가했습니다:
isTargeted: 고객이 지정 요청한 기사님 여부
isLiked: 고객이 찜한 기사님 여부

- 정렬 필드 추가
OrderField enum에 LIKE_COUNT를 추가했습니다.

- 이번 PR이 merge되면 like와 review 작업할 예정입니다.

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

- 전체 기사님 프로필 조회

![image](https://github.com/user-attachments/assets/f4dea55d-6a9f-4b28-a2ab-a9ab00616f13)

- 기사 프로필 상세 조회

![image](https://github.com/user-attachments/assets/e52d8620-7868-4bf1-bbc3-947dd164ab6b)

![image](https://github.com/user-attachments/assets/53b6e5e5-ee49-4c2e-9f4f-fa1ea1a5dad9)

