### PR TITLE
Test/e2e seed flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ pids
 
 # Diagnostic reports (https://nodejs.org/api/report.html)
 report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Test configuration
+/test/config/test.config.ts

--- a/package.json
+++ b/package.json
@@ -22,6 +22,15 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
+    "test:e2e:verbose": "jest --config ./test/jest-e2e.json --verbose",
+    "test:e2e:watch": "jest --config ./test/jest-e2e.json --watch",
+    "test:e2e:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --config ./test/jest-e2e.json --runInBand",
+    "test:e2e:new-user": "jest --config ./test/jest-e2e.json test/new-user.e2e-spec.ts",
+    "test:e2e:new-user:verbose": "jest --config ./test/jest-e2e.json test/new-user.e2e-spec.ts --verbose",
+    "test:e2e:existing-user": "jest --config ./test/jest-e2e.json test/existing-user.e2e-spec.ts",
+    "test:e2e:existing-user:verbose": "jest --config ./test/jest-e2e.json test/existing-user.e2e-spec.ts --verbose",
+    "test:e2e:estimate-flow": "jest --config ./test/jest-e2e.json test/estimate-request-flow.e2e-spec.ts",
+    "test:e2e:estimate-flow:verbose": "jest --config ./test/jest-e2e.json test/estimate-request-flow.e2e-spec.ts --verbose",
     "seed": "ts-node -r tsconfig-paths/register src/seed/index.ts"
   },
   "dependencies": {

--- a/test/config/test.config.example.ts
+++ b/test/config/test.config.example.ts
@@ -1,0 +1,13 @@
+export const TEST_CONFIG = {
+  customer: {
+    email: 'your-customer@example.com',
+    password: 'your-customer-password',
+  },
+  movers: [
+    { email: 'mover1@example.com' },
+    { email: 'mover2@example.com' },
+    { email: 'mover3@example.com' },
+    { email: 'mover4@example.com' },
+  ],
+  defaultPassword: 'your-default-password',
+} as const;

--- a/test/config/test.constants.ts
+++ b/test/config/test.constants.ts
@@ -1,0 +1,113 @@
+import { TEST_CONFIG } from './test.config';
+
+// 랜덤 이름 생성을 위한 배열들
+const ADJECTIVES = [
+  '친절한',
+  '성실한',
+  '믿음직한',
+  '신속한',
+  '정직한',
+  '꼼꼼한',
+  '열정적인',
+  '전문적인',
+  '경험많은',
+  '안전한',
+] as const;
+
+const NOUNS = [
+  '이사왕',
+  '포장달인',
+  '이사전문가',
+  '운송마스터',
+  '이사매니저',
+  '포장전문가',
+  '이사달인',
+  '운송전문가',
+  '이사프로',
+  '포장프로',
+] as const;
+
+// 한국 성씨 배열
+const SURNAMES = [
+  '김',
+  '이',
+  '박',
+  '최',
+  '정',
+  '윤',
+  '민',
+  '강',
+  '조',
+  '윤',
+  '장',
+  '임',
+  '한',
+  '오',
+  '서',
+  '신',
+  '권',
+  '황',
+  '안',
+  '송',
+  '류',
+  '홍',
+] as const;
+
+// 이름 구성요소 배열
+const GIVEN_NAMES = [
+  '조순',
+  '하윤',
+  '세정',
+  '지영',
+  '민호',
+  '은비',
+  '민준',
+  '서준',
+  '도윤',
+  '지호',
+  '지훈',
+  '준서',
+  '준우',
+  '현우',
+  '도현',
+  '지현',
+  '민서',
+  '서연',
+  '서윤',
+  '지윤',
+  '서현',
+  '민지',
+  '수빈',
+  '예은',
+  '예린',
+  '수현',
+] as const;
+
+export const TEST_CONSTANTS = {
+  // 테스트용 기본 비밀번호
+  defaultPassword: TEST_CONFIG.defaultPassword,
+
+  // 테스트용 기본 전화번호 prefix (뒤에 랜덤 숫자가 붙음)
+  PHONE_PREFIX: '0108888',
+
+  // 랜덤 이름 생성용 배열
+  NAME_COMPONENTS: {
+    ADJECTIVES,
+    NOUNS,
+    SURNAMES,
+    GIVEN_NAMES,
+  },
+
+  // 테스트 계정 생성 시 기본값
+  DEFAULT_VALUES: {
+    customerName: '테스트고객',
+    moverNamePrefix: '테스트기사',
+    moverNicknamePrefix: '테스트기사',
+    moverIntro: '안녕하세요! 고객님의 소중한 이사를 도와드리겠습니다.',
+    moverDescription:
+      '신속하고 안전한 이사를 약속드립니다. 포장부터 운송, 정리까지 완벽하게 도와드립니다.',
+  },
+
+  // 테스트용 이메일 도메인
+  TEST_EMAIL_DOMAIN: 'moving.com',
+} as const;

--- a/test/existing-user.e2e-spec.ts
+++ b/test/existing-user.e2e-spec.ts
@@ -1,0 +1,327 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '@/app.module';
+import { getRandomAddress } from './utils/test-helpers';
+import { DataSource } from 'typeorm';
+import { TEST_CONFIG } from './config/test.config';
+
+describe('Estimate Offer Flow (e2e)', () => {
+  let app: INestApplication;
+  let customerToken: string;
+  let moverTokens: string[] = [];
+  let estimateRequestId: string;
+  let dataSource: DataSource;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+
+    // 고객 로그인
+    try {
+      const loginRes = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email: TEST_CONFIG.customer.email,
+          password: TEST_CONFIG.customer.password,
+          role: 'CUSTOMER',
+          provider: 'LOCAL',
+        })
+        .expect(201);
+
+      console.log('고객 로그인 성공:', loginRes.body);
+      customerToken = loginRes.body.accessToken;
+    } catch (error) {
+      console.error('고객 로그인 실패:', {
+        email: TEST_CONFIG.customer.email,
+        errorMessage: error.response?.body?.message || error.message,
+        statusCode: error.response?.status,
+        error: error.response?.body,
+      });
+      throw error;
+    }
+
+    // 기사 로그인
+    for (const mover of TEST_CONFIG.movers) {
+      try {
+        const moverLoginResponse = await request(app.getHttpServer())
+          .post('/auth/login')
+          .send({
+            email: mover.email,
+            password: TEST_CONFIG.defaultPassword,
+            role: 'MOVER',
+            provider: 'LOCAL',
+          });
+
+        console.log(
+          `기사 로그인 성공 (${mover.email}):`,
+          moverLoginResponse.body,
+        );
+        moverTokens.push(moverLoginResponse.body.accessToken);
+      } catch (error) {
+        console.error(`기사 로그인 실패 (${mover.email}):`, {
+          errorMessage: error.response?.body?.message || error.message,
+          statusCode: error.response?.status,
+          error: error.response?.body,
+        });
+        throw error;
+      }
+    }
+
+    // PENDING 상태 견적 요청을 확인하거나 없으면 생성
+    const activeResponse = await request(app.getHttpServer())
+      .get('/estimate-request/active')
+      .set('Authorization', `Bearer ${customerToken}`)
+      .expect(200);
+
+    const activeRequests = activeResponse.body;
+    console.log(
+      '활성 견적 요청 목록:',
+      JSON.stringify(activeRequests, null, 2),
+    );
+
+    // 활성 견적 요청이 있으면 해당 요청 ID 사용
+    estimateRequestId = activeRequests[0]?.estimateRequestId;
+
+    if (!estimateRequestId) {
+      // 견적 요청이 없으면 새로운 견적 요청을 생성
+      console.log(
+        'PENDING 상태 견적 요청이 없으므로 새로운 요청을 생성합니다.',
+      );
+
+      const fromAddress = getRandomAddress();
+      const toAddress = getRandomAddress();
+
+      const createRequestResponse = await request(app.getHttpServer())
+        .post('/estimate-request')
+        .set('Authorization', `Bearer ${customerToken}`)
+        .send({
+          moveType: 'HOME',
+          moveDate: new Date(Date.now() + 24 * 60 * 60 * 1000)
+            .toISOString()
+            .split('T')[0],
+          fromAddress: {
+            sido: fromAddress.sido,
+            sigungu: fromAddress.sigungu,
+            detail: fromAddress.roadAddress,
+          },
+          toAddress: {
+            sido: toAddress.sido,
+            sigungu: toAddress.sigungu,
+            detail: toAddress.roadAddress,
+          },
+        });
+
+      console.log('새로운 견적 요청 생성 응답:', {
+        status: createRequestResponse.status,
+        body: createRequestResponse.body,
+      });
+
+      if (createRequestResponse.status === 201) {
+        estimateRequestId = createRequestResponse.body.id;
+      } else {
+        throw new Error('새로운 견적 요청 생성에 실패했습니다.');
+      }
+    }
+
+    expect(estimateRequestId).toBeDefined();
+    console.log('현재 진행 중인 견적 요청 ID:', estimateRequestId);
+  }, 30000);
+  /**
+   * 테스트 후 애플리케이션을 종료합니다.
+   */
+  afterAll(async () => {
+    await app.close();
+  });
+
+  /**
+   * 각 기사들이 견적 제안을 생성하는 테스트입니다.
+   */
+  it('[MOVER] 견적 제안 생성 테스트', async () => {
+    expect(estimateRequestId).toBeDefined();
+    console.log(`견적 요청 ID: ${estimateRequestId}에 대한 제안 생성 시작`);
+
+    // 견적 요청이 존재하는지 확인
+    const checkRequestResponse = await request(app.getHttpServer())
+      .get(`/estimate-request/active`)
+      .set('Authorization', `Bearer ${customerToken}`)
+      .expect(200);
+    console.log('활성 견적 요청 목록:', checkRequestResponse.body);
+
+    // 견적 요청이 있는지 확인
+    const activeRequest = checkRequestResponse.body.find(
+      (req) => req.estimateRequestId === estimateRequestId,
+    );
+    expect(activeRequest).toBeDefined();
+
+    // 각 기사별로 순차적으로 로그인하고 견적 제안 생성
+    const newOffers = [];
+    for (const mover of TEST_CONFIG.movers) {
+      console.log(`\n[기사 ${mover.email}] 로그인 시도`);
+      // 1. 기사 로그인
+      const moverLoginResponse = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email: mover.email,
+          password: TEST_CONFIG.defaultPassword,
+          role: 'MOVER',
+          provider: 'LOCAL',
+        });
+      const moverToken = moverLoginResponse.body.accessToken;
+      console.log(`[기사 ${mover.email}] 로그인 성공`);
+
+      // 2. 기사 프로필 조회
+      console.log(`[기사 ${mover.email}] 프로필 조회`);
+      const moverProfileResponse = await request(app.getHttpServer())
+        .get('/mover/me')
+        .set('Authorization', `Bearer ${moverToken}`)
+        .expect(200);
+
+      const moverId = moverProfileResponse.body.id;
+      console.log(`[기사 ${mover.email}] 프로필 ID: ${moverId}`);
+
+      // 3. 견적 제안 생성
+      try {
+        // 랜덤 가격 생성 (20만원 ~ 30만원 사이)
+        const price = Math.floor(Math.random() * 100000) + 200000;
+        const offerData = {
+          price,
+          comment: `안녕하세요! ${price.toLocaleString()}원에 빠르고 안전한 이사를 도와드릴 기사입니다. 포장자재 무료, 보험완비, 전문팀 구성으로 진행합니다.`,
+        };
+
+        console.log(`[기사] 견적 제안 생성 시도:`, {
+          estimateRequestId,
+          offerData,
+        });
+
+        const createOfferResponse = await request(app.getHttpServer())
+          .post(`/estimate-offer/${estimateRequestId}`)
+          .set('Authorization', `Bearer ${moverToken}`)
+          .send(offerData);
+
+        console.log(`[기사] 견적 제안 응답:`, {
+          status: createOfferResponse.status,
+          body: createOfferResponse.body,
+        });
+
+        if (createOfferResponse.status !== 201) {
+          throw new Error(
+            `견적 제안 생성 실패: ${JSON.stringify(createOfferResponse.body)}`,
+          );
+        }
+
+        // 4. 생성된 견적 제안 확인
+        console.log(`[기사 ${mover.email}] 견적 제안 조회 시도`);
+        const offersResponse = await request(app.getHttpServer())
+          .get(`/estimate-offer/offers`)
+          .set('Authorization', `Bearer ${moverToken}`)
+          .expect(200);
+
+        // 견적 제안이 실제로 생성되었는지 확인
+        const hasOffer = offersResponse.body.some(
+          (offer) => offer.estimateRequestId === estimateRequestId,
+        );
+        expect(hasOffer).toBe(true);
+        console.log(`[기사 ${mover.email}] 견적 제안 확인 완료`);
+      } catch (error) {
+        console.error(
+          '[기사] 견적 제안 생성 실패:',
+          error.message,
+          '\n상세 에러:',
+          error.response?.text || error.response?.body || error,
+        );
+        throw error;
+      }
+    }
+
+    // 견적 제안이 하나 이상 생성되었는지 확인
+    expect(newOffers.length).toBeGreaterThan(0);
+    console.log(`\n총 ${newOffers.length}개의 견적 제안이 생성되었습니다.`);
+
+    // 5. 고객 입장에서 견적 제안 목록 조회
+    console.log('\n[고객] 받은 견적 제안 목록 조회');
+    const customerOffersResponse = await request(app.getHttpServer())
+      .get(`/estimate-offer/${estimateRequestId}/pending`)
+      .set('Authorization', `Bearer ${customerToken}`)
+      .expect(200);
+
+    console.log('고객이 받은 견적 제안 목록:', customerOffersResponse.body);
+    expect(customerOffersResponse.body.items.length).toBe(newOffers.length);
+  });
+
+  // /**
+  //  * 고객이 가장 저렴한 견적을 선택하여 확정하는 테스트입니다.
+  //  */
+  // it('[CUSTOMER] 견적 제안 확정 테스트', async () => {
+  //   // 견적 요청의 모든 제안 조회
+  //   const offersResponse = await request(app.getHttpServer())
+  //     .get(`/estimate-offer/${estimateRequestId}/pending`)
+  //     .set('Authorization', `Bearer ${customerToken}`);
+  //   console.log(offersResponse);
+  //   const offers = offersResponse.body.items;
+  //   console.log('모든 견적 제안 목록:', offers);
+  //   console.log(`조회된 견적 제안 수: ${offers.length}`);
+  //   if (offers.length === 0) {
+  //     console.log('No offers found.');
+  //     return; // Or handle the error as necessary
+  //   }
+  //   console.log('mover object for first offer:', offers[0]?.mover);
+
+  //   console.log(
+  //     '모든 견적 제안 목록:',
+  //     offers.map((offer) => ({
+  //       id: offer.id,
+  //       price: offer.price,
+  //       mover: offer.mover ? offer.mover.nickname : 'No mover',
+  //     })),
+  //   );
+
+  //   if (offers.length === 0) {
+  //     console.log('견적 제안이 없어 확정 테스트를 진행할 수 없습니다.');
+  //     return;
+  //   }
+
+  //   // 가장 저렴한 견적 제안 선택
+  //   const cheapestOffer = offers.reduce((min, offer) => {
+  //     console.log(
+  //       `비교: 현재 최소 가격 ${min.price} vs 새 가격 ${offer.price}`,
+  //     );
+  //     return +offer.price < +min.price ? offer : min;
+  //   }, offers[0]);
+
+  //   console.log('선택된 견적 제안:', {
+  //     id: cheapestOffer.id,
+  //     price: cheapestOffer.price,
+  //     mover: cheapestOffer.mover.nickname,
+  //   });
+
+  //   console.log(
+  //     `가장 저렴한 견적 제안을 선택합니다. (가격: ${cheapestOffer.price.toLocaleString()}원, 기사: ${cheapestOffer.mover.nickname})`,
+  //   );
+
+  //   try {
+  //     // 선택한 견적 제안 확정
+  //     await request(app.getHttpServer())
+  //       .patch(`/estimate-offer/${cheapestOffer.offerId}/confirmed`)
+  //       .set('Authorization', `Bearer ${customerToken}`)
+  //       .expect(200);
+
+  //     console.log('견적 제안이 성공적으로 확정되었습니다.');
+  //   } catch (error) {
+  //     console.error(
+  //       '견적 제안 확정 중 에러 발생:',
+  //       error.response?.body || error.message,
+  //     );
+  //     console.error('에러 응답 전체:', {
+  //       status: error?.status,
+  //       body: error.response?.body,
+  //       headers: error.response?.headers,
+  //     });
+  //     throw error;
+  //   }
+  // });
+});

--- a/test/jest-e2e.json
+++ b/test/jest-e2e.json
@@ -1,9 +1,19 @@
 {
   "moduleFileExtensions": ["js", "json", "ts"],
-  "rootDir": ".",
+  "rootDir": "..",
   "testEnvironment": "node",
   "testRegex": ".e2e-spec.ts$",
   "transform": {
-    "^.+\\.(t|j)s$": "ts-jest"
-  }
+    "^.+\\.(t|j)s$": [
+      "ts-jest",
+      {
+        "tsconfig": "./tsconfig.json"
+      }
+    ]
+  },
+  "moduleNameMapper": {
+    "^src/(.*)$": "<rootDir>/src/$1",
+    "^@/(.*)$": "<rootDir>/src/$1"
+  },
+  "testPathIgnorePatterns": ["/node_modules/", "/dist/"]
 }

--- a/test/new-user.e2e-spec.ts
+++ b/test/new-user.e2e-spec.ts
@@ -1,0 +1,294 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication } from '@nestjs/common';
+import * as request from 'supertest';
+import { AppModule } from '@/app.module';
+import {
+  createRandomServiceRegion,
+  createRandomServiceType,
+  getRandomAddress,
+  generateRandomName,
+  generateTestEmail,
+} from './utils/test-helpers';
+import { TEST_CONSTANTS } from './config/test.constants';
+//회원가입 + 로그인 + 프로필 생성
+describe('신규 계정 견적 흐름 (회원가입 → 프로필 생성 → 견적)', () => {
+  let app: INestApplication;
+  let customerToken: string;
+  let moverTokens: string[] = [];
+  let customerEmail: string;
+  const NUM_MOVERS = 3;
+
+  // 테스트용 동적 값 생성 함수
+  const generateTestPhone = (index: number = 0) =>
+    `${TEST_CONSTANTS.PHONE_PREFIX}${String(index).padStart(3, '0')}`;
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [AppModule],
+    }).compile();
+
+    app = moduleFixture.createNestApplication();
+    await app.init();
+  }, 30000);
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('고객 회원가입 및 프로필 생성', async () => {
+    customerEmail = generateTestEmail('customer');
+
+    await request(app.getHttpServer())
+      .post('/auth/register')
+      .send({
+        email: customerEmail,
+        password: TEST_CONSTANTS.defaultPassword,
+        name: generateRandomName(),
+        phone: generateTestPhone(),
+        role: 'CUSTOMER',
+        provider: 'LOCAL',
+      })
+      .expect(201);
+
+    const loginRes = await request(app.getHttpServer())
+      .post('/auth/login')
+      .send({
+        email: customerEmail,
+        password: TEST_CONSTANTS.defaultPassword,
+        role: 'CUSTOMER',
+        provider: 'LOCAL',
+      })
+      .expect(201);
+
+    customerToken = loginRes.body.accessToken;
+
+    await request(app.getHttpServer())
+      .post('/customer')
+      .set('Authorization', `Bearer ${customerToken}`)
+      .send({
+        serviceType: createRandomServiceType(),
+        serviceRegion: createRandomServiceRegion(),
+      })
+      .expect(201);
+  });
+
+  it('기사들 회원가입 및 프로필 생성', async () => {
+    for (let i = 0; i < NUM_MOVERS; i++) {
+      const email = generateTestEmail('mover');
+      const moverName = generateRandomName('기사');
+
+      await request(app.getHttpServer())
+        .post('/auth/register')
+        .send({
+          email,
+          password: TEST_CONSTANTS.defaultPassword,
+          name: moverName,
+          phone: generateTestPhone(i),
+          role: 'MOVER',
+          provider: 'LOCAL',
+        })
+        .expect(201);
+
+      const loginRes = await request(app.getHttpServer())
+        .post('/auth/login')
+        .send({
+          email,
+          password: TEST_CONSTANTS.defaultPassword,
+          role: 'MOVER',
+          provider: 'LOCAL',
+        })
+        .expect(201);
+
+      const token = loginRes.body.accessToken;
+      moverTokens.push(token);
+
+      await request(app.getHttpServer())
+        .post('/mover')
+        .set('Authorization', `Bearer ${token}`)
+        .send({
+          nickname: moverName,
+          experience: 5 + i,
+          intro: TEST_CONSTANTS.DEFAULT_VALUES.moverIntro,
+          description: TEST_CONSTANTS.DEFAULT_VALUES.moverDescription,
+          serviceType: createRandomServiceType(),
+          serviceRegion: createRandomServiceRegion(),
+        })
+        .expect(201);
+    }
+  });
+  describe('견적 요청 및 제안 테스트', () => {
+    /**
+     * 견적 요청을 생성하는 함수. 랜덤 주소를 사용하여 견적 요청을 생성합니다.
+     * @returns {string | null} 견적 요청 ID 또는 실패 시 null 반환
+     */
+    const createEstimateRequest = async (): Promise<string | null> => {
+      try {
+        // 랜덤 주소 데이터 가져오기
+        const fromAddress = getRandomAddress();
+        const toAddress = getRandomAddress();
+
+        const response = await request(app.getHttpServer())
+          .post('/estimate-request')
+          .set('Authorization', `Bearer ${customerToken}`)
+          .send({
+            moveType: 'HOME',
+            moveDate: new Date(Date.now() + 24 * 60 * 60 * 1000)
+              .toISOString()
+              .split('T')[0],
+            fromAddress: {
+              sido: fromAddress.sido,
+              sigungu: fromAddress.sigungu,
+              detail: fromAddress.roadAddress,
+            },
+            toAddress: {
+              sido: toAddress.sido,
+              sigungu: toAddress.sigungu,
+              detail: toAddress.roadAddress,
+            },
+          });
+
+        console.log('견적 요청 생성 응답:', {
+          status: response.status,
+          body: response.body,
+        });
+
+        if (response.status === 201) {
+          return response.body.id;
+        }
+        console.error('견적 요청 생성 실패:', response.body);
+        return null;
+      } catch (error) {
+        console.error(
+          '견적 요청 생성 중 에러 발생:',
+          error.response?.body || error.message,
+        );
+        return null;
+      }
+    };
+    let estimateRequestId: string;
+    /**
+     * 진행 중인 견적 요청이 없으면 새로운 견적 요청을 생성하고,
+     * 있으면 해당 요청 ID를 사용합니다.
+     */
+    it('고객의 PENDING 상태 견적 요청을 확인하고 없으면 생성해야 한다', async () => {
+      // 진행 중인 견적 요청 조회
+      const activeResponse = await request(app.getHttpServer())
+        .get('/estimate-request/active')
+        .set('Authorization', `Bearer ${customerToken}`)
+        .expect(200);
+
+      const activeRequests = activeResponse.body;
+      console.log(
+        '활성 견적 요청 목록:',
+        JSON.stringify(activeRequests, null, 2),
+      );
+
+      if (Array.isArray(activeRequests) && activeRequests.length > 0) {
+        // 진행 중인 견적 요청이 있는 경우
+        estimateRequestId = activeRequests[0].estimateRequestId;
+        console.log(
+          `이미 진행 중인 견적 요청이 있습니다. ID: ${estimateRequestId}`,
+        );
+      } else {
+        // 진행 중인 견적 요청이 없으면 새로 생성
+        estimateRequestId = await createEstimateRequest();
+        if (!estimateRequestId) {
+          throw new Error('견적 요청 생성 실패');
+        }
+      }
+
+      expect(estimateRequestId).toBeDefined();
+      console.log('현재 진행 중인 견적 요청 ID:', estimateRequestId);
+    });
+
+    /**
+     * 각 기사들이 견적 제안을 생성하는 테스트입니다.
+     */
+    it('[MOVER] 견적 제안 생성 테스트', async () => {
+      expect(estimateRequestId).toBeDefined();
+      console.log(`견적 요청 ID: ${estimateRequestId}에 대한 제안 생성 시작`);
+
+      // 견적 요청이 존재하는지 확인
+      const checkRequestResponse = await request(app.getHttpServer())
+        .get(`/estimate-request/active`)
+        .set('Authorization', `Bearer ${customerToken}`)
+        .expect(200);
+      console.log('활성 견적 요청 목록:', checkRequestResponse.body);
+
+      // 견적 요청이 있는지 확인
+      const activeRequest = checkRequestResponse.body.find(
+        (req) => req.estimateRequestId === estimateRequestId,
+      );
+      expect(activeRequest).toBeDefined();
+
+      // 각 기사별로 순차적으로 로그인하고 견적 제안 생성
+      const newOffers = [];
+      for (const moverToken of moverTokens) {
+        // 2. 기사 프로필 조회
+        console.log('[기사] 프로필 조회');
+        const moverProfileResponse = await request(app.getHttpServer())
+          .get('/mover/me')
+          .set('Authorization', `Bearer ${moverToken}`)
+          .expect(200);
+
+        const moverId = moverProfileResponse.body.id;
+        console.log(`[기사] 프로필 ID: ${moverId}`);
+
+        // 3. 견적 제안 생성
+        try {
+          // 랜덤 가격 생성 (20만원 ~ 30만원 사이)
+          const price = Math.floor(Math.random() * 100000) + 200000;
+          const offerData = {
+            price,
+            comment: `안녕하세요! ${price.toLocaleString()}원에 빠르고 안전한 이사를 도와드릴 기사입니다. 포장자재 무료, 보험완비, 전문팀 구성으로 진행합니다.`,
+          };
+
+          const createOfferResponse = await request(app.getHttpServer())
+            .post(`/estimate-offer/${estimateRequestId}`)
+            .set('Authorization', `Bearer ${moverToken}`)
+            .send(offerData)
+            .expect(201);
+          console.log(
+            `[기사] 견적 제안 생성 성공 (가격: ${price.toLocaleString()}원)`,
+          );
+          newOffers.push(createOfferResponse.body);
+
+          // 4. 생성된 견적 제안 확인
+          console.log('[기사] 견적 제안 조회 시도');
+          const offersResponse = await request(app.getHttpServer())
+            .get(`/estimate-offer/offers`)
+            .set('Authorization', `Bearer ${moverToken}`)
+            .expect(200);
+
+          // 견적 제안이 실제로 생성되었는지 확인
+          const hasOffer = offersResponse.body.some(
+            (offer) => offer.estimateRequestId === estimateRequestId,
+          );
+          expect(hasOffer).toBe(true);
+          console.log('[기사] 견적 제안 확인 완료');
+        } catch (error) {
+          console.error(
+            '[기사] 견적 제안 생성 실패:',
+            error.response?.body,
+            '\n상세 에러:',
+            error.response?.text,
+          );
+        }
+      }
+
+      // 견적 제안이 하나 이상 생성되었는지 확인
+      expect(newOffers.length).toBeGreaterThan(0);
+      console.log(`\n총 ${newOffers.length}개의 견적 제안이 생성되었습니다.`);
+
+      // 5. 고객 입장에서 견적 제안 목록 조회
+      console.log('\n[고객] 받은 견적 제안 목록 조회');
+      const customerOffersResponse = await request(app.getHttpServer())
+        .get(`/estimate-offer/${estimateRequestId}/pending`)
+        .set('Authorization', `Bearer ${customerToken}`)
+        .expect(200);
+
+      console.log('고객이 받은 견적 제안 목록:', customerOffersResponse.body);
+      expect(customerOffersResponse.body.items.length).toBe(newOffers.length);
+    });
+  });
+});

--- a/test/utils/test-helpers.ts
+++ b/test/utils/test-helpers.ts
@@ -1,0 +1,251 @@
+import { ServiceRegion } from '@/common/const/service.const';
+import { TEST_CONSTANTS } from '../config/test.constants';
+
+export const randomBoolean = () => Math.random() < 0.5;
+
+// 랜덤 숫자 생성 함수 (min과 max 사이의 정수)
+export const getRandomNumber = (min: number, max: number) =>
+  Math.floor(Math.random() * (max - min + 1)) + min;
+
+// 배열에서 랜덤 요소 선택
+export const getRandomElement = <T>(array: readonly T[]): T =>
+  array[Math.floor(Math.random() * array.length)];
+
+// 이메일 생성을 위한 간단한 영문 이름 배열
+const SIMPLE_NAMES = ['user', 'customer', 'test', 'mover', 'moving'] as const;
+
+// 간단한 이메일 생성 함수
+export const generateTestEmail = (role: 'customer' | 'mover' = 'customer') => {
+  const name = getRandomElement(SIMPLE_NAMES);
+  const number = getRandomNumber(1, 9999).toString().padStart(4, '0');
+  return `${role}.${name}${number}@${TEST_CONSTANTS.TEST_EMAIL_DOMAIN}`;
+};
+
+// 한국식 이름을 이용한 이메일 생성 함수
+export const generateEmailFromName = (koreanName: string) => {
+  const number = getRandomNumber(1, 999).toString().padStart(3, '0');
+  // 한글 이름을 영문자로 변환 (초성 추출)
+  const nameForEmail = koreanName.replace(/[^ㄱ-ㅎ가-힣]/g, '').substring(0, 3);
+  return `${nameForEmail}${number}@${TEST_CONSTANTS.TEST_EMAIL_DOMAIN}`;
+};
+
+// 한국식 이름 생성 함수
+export const generateKoreanName = () => {
+  const surname = getRandomElement(TEST_CONSTANTS.NAME_COMPONENTS.SURNAMES);
+  const givenName = getRandomElement(
+    TEST_CONSTANTS.NAME_COMPONENTS.GIVEN_NAMES,
+  );
+  return `${surname}${givenName}`;
+};
+
+// 랜덤 이름 생성 함수
+export const generateRandomName = (prefix: string = '') => {
+  if (!prefix) {
+    // 고객의 경우 한국식 이름 사용
+    return generateKoreanName();
+  }
+  // 기사의 경우 기존 형식 사용
+  const adjective = getRandomElement(TEST_CONSTANTS.NAME_COMPONENTS.ADJECTIVES);
+  const number = getRandomNumber(1, 999).toString().padStart(3, '0');
+  return `${prefix}_${adjective}${number}`;
+};
+
+export const createRandomServiceType = () => ({
+  SMALL: randomBoolean(),
+  HOME: randomBoolean(),
+  OFFICE: randomBoolean(),
+});
+
+export const createRandomServiceRegion = () => ({
+  [ServiceRegion.SEOUL]: randomBoolean(),
+  [ServiceRegion.GYEONGGI]: randomBoolean(),
+  [ServiceRegion.INCHEON]: randomBoolean(),
+  [ServiceRegion.GANGWON]: randomBoolean(),
+  [ServiceRegion.CHUNGBUK]: randomBoolean(),
+  [ServiceRegion.CHUNGNAM]: randomBoolean(),
+  [ServiceRegion.SEJONG]: randomBoolean(),
+  [ServiceRegion.DAEJEON]: randomBoolean(),
+  [ServiceRegion.JEONBUK]: randomBoolean(),
+  [ServiceRegion.JEONNAM]: randomBoolean(),
+  [ServiceRegion.GWANGJU]: randomBoolean(),
+  [ServiceRegion.GYEONGBUK]: randomBoolean(),
+  [ServiceRegion.GYEONGNAM]: randomBoolean(),
+  [ServiceRegion.DAEGU]: randomBoolean(),
+  [ServiceRegion.ULSAN]: randomBoolean(),
+  [ServiceRegion.BUSAN]: randomBoolean(),
+  [ServiceRegion.JEJU]: randomBoolean(),
+});
+
+export const addressData = [
+  {
+    sido: '서울',
+    sidoEnglish: 'Seoul',
+    sigungu: '강남구',
+    roadAddress: '서울특별시 강남구 테헤란로 123',
+    fullAddress: '서울특별시 강남구 역삼동 123-45',
+  },
+  {
+    sido: '부산',
+    sidoEnglish: 'Busan',
+    sigungu: '해운대구',
+    roadAddress: '부산광역시 해운대구 센텀중앙로 456',
+    fullAddress: '부산광역시 해운대구 우동 456-78',
+  },
+  {
+    sido: '대구',
+    sidoEnglish: 'Daegu',
+    sigungu: '수성구',
+    roadAddress: '대구광역시 수성구 동대구로 789',
+    fullAddress: '대구광역시 수성구 범어동 789-12',
+  },
+  {
+    sido: '인천',
+    sidoEnglish: 'Incheon',
+    sigungu: '연수구',
+    roadAddress: '인천광역시 연수구 송도과학로 101',
+    fullAddress: '인천광역시 연수구 송도동 101-11',
+  },
+  {
+    sido: '광주',
+    sidoEnglish: 'Gwangju',
+    sigungu: '북구',
+    roadAddress: '광주광역시 북구 무등로 321',
+    fullAddress: '광주광역시 북구 중흥동 321-33',
+  },
+  {
+    sido: '대전',
+    sidoEnglish: 'Daejeon',
+    sigungu: '서구',
+    roadAddress: '대전광역시 서구 둔산로 202',
+    fullAddress: '대전광역시 서구 둔산동 202-22',
+  },
+  {
+    sido: '울산',
+    sidoEnglish: 'Ulsan',
+    sigungu: '남구',
+    roadAddress: '울산광역시 남구 삼산로 404',
+    fullAddress: '울산광역시 남구 삼산동 404-44',
+  },
+  {
+    sido: '세종',
+    sidoEnglish: 'Sejong-si',
+    sigungu: '세종시',
+    roadAddress: '세종특별자치시 한누리대로 1234',
+    fullAddress: '세종특별자치시 보람동 1234-56',
+  },
+  {
+    sido: '경기도',
+    sidoEnglish: 'Gyeonggi-do',
+    sigungu: '성남시 분당구',
+    roadAddress: '경기도 성남시 분당구 판교로 88',
+    fullAddress: '경기도 성남시 분당구 삼평동 88-12',
+  },
+  {
+    sido: '강원도',
+    sidoEnglish: 'Gangwon-do',
+    sigungu: '춘천시',
+    roadAddress: '강원도 춘천시 중앙로 55',
+    fullAddress: '강원도 춘천시 석사동 55-10',
+  },
+  {
+    sido: '충청북도',
+    sidoEnglish: 'Chungcheongbuk-do',
+    sigungu: '청주시',
+    roadAddress: '충청북도 청주시 상당로 66',
+    fullAddress: '충청북도 청주시 상당구 북문로2가 66-77',
+  },
+  {
+    sido: '충청남도',
+    sidoEnglish: 'Chungcheongnam-do',
+    sigungu: '천안시',
+    roadAddress: '충청남도 천안시 서북구 불당대로 77',
+    fullAddress: '충청남도 천안시 불당동 77-88',
+  },
+  {
+    sido: '전라북도',
+    sidoEnglish: 'Jeonbuk-do',
+    sigungu: '전주시',
+    roadAddress: '전라북도 전주시 완산구 전주천동로 22',
+    fullAddress: '전라북도 전주시 효자동 22-33',
+  },
+  {
+    sido: '전라남도',
+    sidoEnglish: 'Jeollanam-do',
+    sigungu: '여수시',
+    roadAddress: '전라남도 여수시 이순신로 99',
+    fullAddress: '전라남도 여수시 학동 99-11',
+  },
+  {
+    sido: '경상북도',
+    sidoEnglish: 'Gyeongsangbuk-do',
+    sigungu: '포항시',
+    roadAddress: '경상북도 포항시 북구 중앙로 303',
+    fullAddress: '경상북도 포항시 죽도동 303-13',
+  },
+  {
+    sido: '경상남도',
+    sidoEnglish: 'Gyeongsangnam-do',
+    sigungu: '창원시',
+    roadAddress: '경상남도 창원시 의창구 창원대로 555',
+    fullAddress: '경상남도 창원시 중동 555-66',
+  },
+  {
+    sido: '제주도',
+    sidoEnglish: 'Jeju-do',
+    sigungu: '제주시',
+    roadAddress: '제주특별자치도 제주시 중앙로 888',
+    fullAddress: '제주특별자치도 제주시 이도이동 888-99',
+  },
+  {
+    sido: '경기도',
+    sidoEnglish: 'Gyeonggi-do',
+    sigungu: '고양시 일산동구',
+    roadAddress: '경기도 고양시 일산동구 정발산로 77',
+    fullAddress: '경기도 고양시 장항동 77-55',
+  },
+  {
+    sido: '전라남도',
+    sidoEnglish: 'Jeollanam-do',
+    sigungu: '순천시',
+    roadAddress: '전라남도 순천시 중앙로 45',
+    fullAddress: '전라남도 순천시 장천동 45-21',
+  },
+  {
+    sido: '충청북도',
+    sidoEnglish: 'Chungcheongbuk-do',
+    sigungu: '제천시',
+    roadAddress: '충청북도 제천시 의림대로 112',
+    fullAddress: '충청북도 제천시 의림동 112-90',
+  },
+  {
+    sido: '서울',
+    sidoEnglish: 'Seoul',
+    sigungu: '영등포구',
+    roadAddress: '서울특별시 영등포구 여의대로 555',
+    fullAddress: '서울특별시 영등포구 여의도동 555-66',
+  },
+  {
+    sido: '광주',
+    sidoEnglish: 'Gwangju',
+    sigungu: '남구',
+    roadAddress: '광주광역시 남구 양림로 666',
+    fullAddress: '광주광역시 남구 양림동 666-77',
+  },
+  {
+    sido: '울산',
+    sidoEnglish: 'Ulsan',
+    sigungu: '북구',
+    roadAddress: '울산광역시 북구 산업로 777',
+    fullAddress: '울산광역시 북구 산업동 777-88',
+  },
+  {
+    sido: '제주',
+    sidoEnglish: 'Jeju-do',
+    sigungu: '서귀포시',
+    roadAddress: '제주특별자치도 서귀포시 일대로 888',
+    fullAddress: '제주특별자치도 서귀포시 일대동 888-99',
+  },
+];
+
+export const getRandomAddress = () =>
+  addressData[Math.floor(Math.random() * addressData.length)];


### PR DESCRIPTION
## 🧚 변경사항 설명

- 실제 API 요청을 통해 시드 데이터 생성하는 e2e test code
- new-user.e2e : 계정 새로 생성하면서 (고객1, 기사 여러명), 고객이 견적 요청 생성하고, 기사들이 그 견적 요청에 offer 생성하는 테스트
- existing-user.e2e: DB에 존재하는 고객 계정과 기사들 계정을 test.config파일에 입력하여 그 계정들로 견적 요청 및 제안 생성하는 테스트( 제안 확정까지 하는 코드는 현재 주석처리되어있음) 
  - 존재하는 계정 ID와 비밀번호를 주어야해서 보안상 test.config 파일로 분리했고, .gitignore 파일에 github 안올라가도록 설정했습니다. 노션에 관련 내용 정리해두었습니다. 참고해서 .gitignore 파일의 내용과 test.config 파일 추가해주세요.
 https://positive-kingfisher-003.notion.site/e2e-21ed9fa672ba805c88c7fc48bc62f5c0?source=copy_link 
- test\estimate-request-flow.e2e: 견적 요청만 생성 (현재 사용 X)
 
## 🧑🏻‍🏫 To-do

- 추가 시드 생성 flow 가 필요한 경우(이사완료, 리뷰 작성..) api를 타지않고 강제로 seed DB에 추가하는 스크립트 이용하거나, 수작업, api 추가 필요함
- 커서 페이지네이션 프론트에서 데이터 불러올때 발생하는 버그 해결하기

## 🎤 공유 사항

- test-helpers 파일에 랜덤 주소 데이터, 이름 랜덤 생성, 서비스타입과 지역 랜덤 boolean 함수 등 있습니다.
![image](https://github.com/user-attachments/assets/1c7521d0-d7b8-4d4c-a37f-591de2c64734)

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes#110

## 📸 스크린샷
- new-user 테스트 성공시
![Screenshot 2025-06-26 110113](https://github.com/user-attachments/assets/63177215-8a1c-426b-920f-d8fdbea660cf)
- 새로 생성한 db로 테스트해서 계정들 생성되는것 확인
![Screenshot 2025-06-26 113742](https://github.com/user-attachments/assets/d0ff9577-ae6b-400e-bb29-79a42ff032cf)
- 고객 계정으로 견적 요청 생성 확인
![Screenshot 2025-06-26 105212](https://github.com/user-attachments/assets/6d4cbdc3-e007-460e-8dcb-d50fc9f6497e)
- 기사들 계정으로 견적 요청에 대한 견적 제안 생성 확인
![Screenshot 2025-06-26 105233](https://github.com/user-attachments/assets/7835f403-f7ae-48d8-b74f-a5f038fbc29d)
- 실제 생성된 계정으로 로그인해서 기사 3명에게 제안 온 것 확인
![image](https://github.com/user-attachments/assets/e8ca0e34-db68-44e0-b93a-2a9c5dc046e0)
- 생성된 기사 계정 로그인해서 고객에게 보낸 제안 확인
![image](https://github.com/user-attachments/assets/7a212d68-a49c-4462-af5e-3689889f2b50)