### PR TITLE
refactor: 기사 뷰테이블에서 서브쿼리를 사용하여 중복 제거

### DIFF
--- a/src/mover-profile/view/mover-profile.view.ts
+++ b/src/mover-profile/view/mover-profile.view.ts
@@ -1,4 +1,3 @@
-// import { Review } from '@/review/entities/review.entity';
 import {
   DataSource,
   JoinColumn,
@@ -7,8 +6,6 @@ import {
   ViewEntity,
 } from 'typeorm';
 import { MoverProfile } from '../entities/mover-profile.entity';
-// import { EstimateOffer } from '@/estimate-offer/entities/estimate-offer.entity';
-// import { Like } from '@/like/entities/like.entity';
 import { OrderField } from '@/common/validator/order.validator';
 
 @ViewEntity({

--- a/src/mover-profile/view/mover-profile.view.ts
+++ b/src/mover-profile/view/mover-profile.view.ts
@@ -1,4 +1,4 @@
-import { Review } from '@/review/entities/review.entity';
+// import { Review } from '@/review/entities/review.entity';
 import {
   DataSource,
   JoinColumn,
@@ -7,35 +7,55 @@ import {
   ViewEntity,
 } from 'typeorm';
 import { MoverProfile } from '../entities/mover-profile.entity';
-import { EstimateOffer } from '@/estimate-offer/entities/estimate-offer.entity';
-import { Like } from '@/like/entities/like.entity';
+// import { EstimateOffer } from '@/estimate-offer/entities/estimate-offer.entity';
+// import { Like } from '@/like/entities/like.entity';
 import { OrderField } from '@/common/validator/order.validator';
 
 @ViewEntity({
   name: 'mover_profile_view', // 뷰의 이름을 'mover_profile_view'로 설정
-  expression: (dataSource: DataSource) =>
-    dataSource
+  expression: (dataSource: DataSource) => {
+    const reviewCountSubQuery = dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)')
+      .from((subQuery) => {
+        return subQuery
+          .select('1')
+          .from('review', 'r')
+          .where('r."moverId" = mover.id')
+          .groupBy('r."estimateOfferId", r."customerId"');
+      }, 'review_group');
+
+    const avgRatingSubQuery = dataSource
+      .createQueryBuilder()
+      .select('COALESCE(AVG(r.rating), 0.0)')
+      .from('review', 'r')
+      .where('r."moverId" = mover.id');
+
+    const confirmedEstimateCountSubQuery = dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)')
+      .from('estimate_offer', 'offer')
+      .where('offer."moverId" = mover.id')
+      .andWhere(`offer.status IN ('CONFIRMED', 'COMPLETED')`);
+
+    const likeCountSubQuery = dataSource
+      .createQueryBuilder()
+      .select('COUNT(*)')
+      .from('like', 'l')
+      .where('l."moverId" = mover.id');
+
+    return dataSource
       .createQueryBuilder()
       .select('mover.id', 'id')
+      .addSelect(`(${reviewCountSubQuery.getQuery()})`, OrderField.REVIEW_COUNT)
+      .addSelect(`(${avgRatingSubQuery.getQuery()})`, OrderField.AVERAGE_RATING)
       .addSelect(
-        'COUNT(DISTINCT (review.estimate_offer_id, review.customer_id))',
-        OrderField.REVIEW_COUNT,
-      )
-      .addSelect('COALESCE(AVG(review.rating), 0.0)', OrderField.AVERAGE_RATING)
-      .addSelect(
-        `COUNT(DISTINCT CASE WHEN estimate_offer.status = 'CONFIRMED' THEN estimate_offer.id ELSE NULL END)`,
+        `(${confirmedEstimateCountSubQuery.getQuery()})`,
         OrderField.CONFIRMED_ESTIMATE_COUNT,
       )
-      .addSelect('COUNT(DISTINCT like.customerId)', OrderField.LIKE_COUNT)
-      .from(MoverProfile, 'mover')
-      .leftJoin(Review, 'review', 'review.moverId = mover.id')
-      .leftJoin(
-        EstimateOffer,
-        'estimate_offer',
-        'estimate_offer.moverId = mover.id',
-      )
-      .leftJoin(Like, 'like', 'like.moverId = mover.id')
-      .groupBy('mover.id'),
+      .addSelect(`(${likeCountSubQuery.getQuery()})`, OrderField.LIKE_COUNT)
+      .from(MoverProfile, 'mover');
+  },
 })
 export class MoverProfileView {
   @ViewColumn()


### PR DESCRIPTION
## 🧚 변경사항 설명

- 뷰테이블의 속성들을 모두 서브쿼리로 각자 따로 계산하여 중복을 제거 함
- 그리고 확정건수는 confirmed 뿐만 아닌 completed도 합산하는 로직으로 수정 

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

만약 테스트 하다가 안되시면 DB에서
```sql
DROP VIEW IF EXISTS mover_profile_view;
```
위 코드 실행하여 뷰테이블 삭제 후 다시 테스트 하시면 됩니다.

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷

<img width="1065" alt="스크린샷 2025-06-26 19 56 26" src="https://github.com/user-attachments/assets/63270946-cc0e-4676-8d7a-6cddc5bfb028" />
