### PR TITLE
Feat/견적요청취소 API

### DIFF
--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -254,3 +254,94 @@ export function ApiGetRequestListForMover() {
     ApiResponse({ status: 403, description: '기사 권한이 없는 사용자' }),
   );
 }
+
+export function ApiCancelEstimateRequest() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '견적 요청 취소',
+      description: '고객이 자신의 PENDING 상태의 견적 요청을 취소합니다.',
+    }),
+    ApiParam({
+      name: 'requestId',
+      required: true,
+      description: '견적 요청 ID',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '견적 요청 취소 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '견적 요청이 취소되었습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '대기 중인 견적 요청만 취소할 수 있습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Bad Request',
+          },
+          statusCode: {
+            type: 'number',
+            example: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '권한 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '견적 요청 취소 권한이 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Forbidden',
+          },
+          statusCode: {
+            type: 'number',
+            example: 403,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '견적 요청을 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '견적 요청을 찾을 수 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Not Found',
+          },
+          statusCode: {
+            type: 'number',
+            example: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -125,40 +125,18 @@ export function ApiGetMyEstimateHistory() {
 export function ApiGetMyActiveEstimateRequest() {
   return applyDecorators(
     ApiOperation({
-      summary: '진행 중인 견적 요청 ID 조회',
-      description: 'PENDING 상태의 견적 요청 ID만 반환합니다.',
+      summary: '진행 중인 견적 요청 조회',
+      description: 'PENDING 상태의 견적 요청 정보를 반환합니다.',
     }),
+    ApiExtraModels(EstimateRequestResponseDto),
     ApiResponse({
       status: 200,
-      description: '진행 중인 견적 요청이 없을 경우 메시지를 반환합니다.',
-      schema: {
-        oneOf: [
-          {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                estimateRequestId: {
-                  type: 'string',
-                  example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-                },
-              },
-            },
-          },
-          {
-            type: 'object',
-            properties: {
-              message: {
-                type: 'string',
-                example: '현재 진행중인 견적 요청이 없습니다.',
-              },
-            },
-          },
-        ],
-      },
+      description: '진행 중인 견적 요청 ',
+      type: [EstimateRequestResponseDto],
     }),
   );
 }
+
 export function ApiAddTargetMover() {
   return applyDecorators(
     ApiOperation({

--- a/src/estimate-request/dto/estimate-request-response.dto.ts
+++ b/src/estimate-request/dto/estimate-request-response.dto.ts
@@ -17,19 +17,19 @@ export class EstimateRequestResponseDto {
 
   isTargeted?: boolean;
   customerName?: string;
-  offerCount: number; //받은 offer 개수 (request랑 offer 응답에서 구분하기 쉽게 추가했는데 필요없으면 제거 가능)
-  estimateOffers?: EstimateOfferResponseDto[];
+  offerCount: number = 0; // 기본값 0으로 설정
+  estimateOffers?: EstimateOfferResponseDto[]; // 옵셔널로 변경
 
   /**
    * 정적 팩토리 메서드
    * @param request EstimateRequest 엔티티
-   * @param offers 연결된 제안 목록 DTO들
+   * @param offers 연결된 제안 목록 DTO들 (옵셔널)
    * @param options 주소 포함 여부 및 기타 옵션
    * @returns EstimateRequestResponseDto 인스턴스
    */
   static from(
     request: EstimateRequest,
-    offers: EstimateOfferResponseDto[] = [],
+    offers?: EstimateOfferResponseDto[],
     options?: {
       includeAddress?: boolean;
       includeMinimalAddress?: boolean;
@@ -43,8 +43,13 @@ export class EstimateRequestResponseDto {
     dto.createdAt = request.createdAt;
     dto.moveType = request.moveType;
     dto.moveDate = request.moveDate;
-    dto.estimateOffers = offers;
-    dto.offerCount = offers.length;
+
+    // offers가 존재하고 비어있지 않은 경우에만 할당
+    if (offers?.length) {
+      dto.estimateOffers = offers;
+      dto.offerCount = offers.length;
+    }
+
     dto.isTargeted = isTargeted ?? false;
 
     // customer.user.name 설정

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -31,12 +31,14 @@ export class EstimateRequestController {
   constructor(
     private readonly estimateRequestService: EstimateRequestService,
   ) {}
-  //INFO: 개발용 해당 고객의 진행 중인 견적 요청 ID 조회 API
+  // 고객의 진행 중인 견적 요청 조회 API
   @Get('active')
   @ApiGetMyActiveEstimateRequest()
   @RBAC(Role.CUSTOMER)
-  async getMyActiveEstimateRequest(@UserInfo() user: UserInfo) {
-    return this.estimateRequestService.findActiveEstimateRequestIds(user.sub);
+  async getMyActiveEstimateRequest(
+    @UserInfo() user: UserInfo,
+  ): Promise<EstimateRequestResponseDto[]> {
+    return this.estimateRequestService.findActiveEstimateRequests(user.sub);
   }
 
   @Post()

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiGetMyActiveEstimateRequest,
   ApiGetMyEstimateHistory,
   ApiGetRequestListForMover,
+  ApiCancelEstimateRequest,
 } from './docs/swagger';
 import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
 import { EstimateRequestResponseDto } from './dto/estimate-request-response.dto';
@@ -91,6 +92,20 @@ export class EstimateRequestController {
       user.sub,
       pagination,
     );
+  }
+
+  @Patch(':requestId/cancel')
+  @RBAC(Role.CUSTOMER)
+  @ApiCancelEstimateRequest()
+  async cancelEstimateRequest(
+    @Param('requestId') requestId: string,
+    @UserInfo() user: UserInfo,
+  ) {
+    await this.estimateRequestService.cancelEstimateRequest(
+      requestId,
+      user.sub,
+    );
+    return { message: '견적 요청이 성공적으로 취소되었습니다.' };
   }
 
   // @Delete(':id')


### PR DESCRIPTION
## 🧚 변경사항 설명

- 고객이 진행중인 견적 요청 취소하는 API 
- [PATCH] /api/estimate-request/{requestId}/cancel
  - 상태를 CANCLED로 변경함
  - 이미 기사가 견적 제안을 한 경우, 관련 견적 제안의 상태도 CANCELED로 변경 


## 🧑🏻‍🏫 To-do

- 이사 완료 확인 API

## 🎤 공유 사항

<!-- 기타 팀원들이 참고해야 할 사항이 있으면 작성해주세요  -->

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #117

## 📸 스크린샷

![Screenshot 2025-06-27 150915](https://github.com/user-attachments/assets/d23052c8-9bd0-4452-87dc-cde8eed5bda5)

- 존재하는 계정들로 견적 요청 & 제안 생성하는 테스트 코드 실행하여 진행중인 견적 요청과 제안들 생성 후 API 실행
- 견적 요청 상태 CANCLED로 변경 확인
<img width="598" alt="Screenshot 2025-06-27 151141" src="https://github.com/user-attachments/assets/22bc4aa3-f160-4b38-9111-9808a5d25fed" />

- 해당 견적 요청에 대한 견적 제안들도 상태 변경 확인
<img width="755" alt="Screenshot 2025-06-27 151035" src="https://github.com/user-attachments/assets/292c9b6f-cb9c-4417-a63a-d811e6f611c9" />
