### PR TITLE
Feat/이사완료

### DIFF
--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -254,3 +254,94 @@ export function ApiGetRequestListForMover() {
     ApiResponse({ status: 403, description: '기사 권한이 없는 사용자' }),
   );
 }
+
+export function ApiCancelEstimateRequest() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '견적 요청 취소',
+      description: '고객이 자신의 PENDING 상태의 견적 요청을 취소합니다.',
+    }),
+    ApiParam({
+      name: 'requestId',
+      required: true,
+      description: '견적 요청 ID',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '견적 요청 취소 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '견적 요청이 취소되었습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '대기 중인 견적 요청만 취소할 수 있습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Bad Request',
+          },
+          statusCode: {
+            type: 'number',
+            example: 400,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '권한 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '견적 요청 취소 권한이 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Forbidden',
+          },
+          statusCode: {
+            type: 'number',
+            example: 403,
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '견적 요청을 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '견적 요청을 찾을 수 없습니다.',
+          },
+          error: {
+            type: 'string',
+            example: 'Not Found',
+          },
+          statusCode: {
+            type: 'number',
+            example: 404,
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -345,3 +345,71 @@ export function ApiCancelEstimateRequest() {
     }),
   );
 }
+
+export function ApiCompleteEstimateRequest() {
+  return applyDecorators(
+    ApiOperation({
+      summary: '이사 완료 처리',
+      description:
+        '고객이 이사를 완료한 후, 견적 요청과 견적 제안의 상태를 CONFIRMED -> COMPLETED로 변경합니다.',
+    }),
+    ApiParam({
+      name: 'requestId',
+      required: true,
+      description: '견적 요청 ID',
+      type: 'string',
+    }),
+    ApiResponse({
+      status: 200,
+      description: '이사 완료 처리 성공',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '이사가 성공적으로 완료 처리되었습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 400,
+      description: '잘못된 요청',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '확정된 견적 요청만 완료 처리할 수 있습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 403,
+      description: '권한 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '이사 완료 처리 권한이 없습니다.',
+          },
+        },
+      },
+    }),
+    ApiResponse({
+      status: 404,
+      description: '리소스를 찾을 수 없음',
+      schema: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            example: '견적 요청을 찾을 수 없습니다.',
+          },
+        },
+      },
+    }),
+  );
+}

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -275,7 +275,7 @@ export function ApiCancelEstimateRequest() {
         properties: {
           message: {
             type: 'string',
-            example: '견적 요청이 취소되었습니다.',
+            example: '견적 요청이 성공적으로 취소되었습니다.',
           },
         },
       },

--- a/src/estimate-request/docs/swagger.ts
+++ b/src/estimate-request/docs/swagger.ts
@@ -125,40 +125,18 @@ export function ApiGetMyEstimateHistory() {
 export function ApiGetMyActiveEstimateRequest() {
   return applyDecorators(
     ApiOperation({
-      summary: '진행 중인 견적 요청 ID 조회',
-      description: 'PENDING 상태의 견적 요청 ID만 반환합니다.',
+      summary: '진행 중인 견적 요청 조회',
+      description: 'PENDING 상태의 견적 요청 정보를 반환합니다.',
     }),
+    ApiExtraModels(EstimateRequestResponseDto),
     ApiResponse({
       status: 200,
-      description: '진행 중인 견적 요청이 없을 경우 메시지를 반환합니다.',
-      schema: {
-        oneOf: [
-          {
-            type: 'array',
-            items: {
-              type: 'object',
-              properties: {
-                estimateRequestId: {
-                  type: 'string',
-                  example: '3fa85f64-5717-4562-b3fc-2c963f66afa6',
-                },
-              },
-            },
-          },
-          {
-            type: 'object',
-            properties: {
-              message: {
-                type: 'string',
-                example: '현재 진행중인 견적 요청이 없습니다.',
-              },
-            },
-          },
-        ],
-      },
+      description: '진행 중인 견적 요청 ',
+      type: [EstimateRequestResponseDto],
     }),
   );
 }
+
 export function ApiAddTargetMover() {
   return applyDecorators(
     ApiOperation({

--- a/src/estimate-request/dto/estimate-request-response.dto.ts
+++ b/src/estimate-request/dto/estimate-request-response.dto.ts
@@ -17,19 +17,19 @@ export class EstimateRequestResponseDto {
 
   isTargeted?: boolean;
   customerName?: string;
-  offerCount: number; //받은 offer 개수 (request랑 offer 응답에서 구분하기 쉽게 추가했는데 필요없으면 제거 가능)
-  estimateOffers?: EstimateOfferResponseDto[];
+  offerCount: number = 0; // 기본값 0으로 설정
+  estimateOffers?: EstimateOfferResponseDto[]; // 옵셔널로 변경
 
   /**
    * 정적 팩토리 메서드
    * @param request EstimateRequest 엔티티
-   * @param offers 연결된 제안 목록 DTO들
+   * @param offers 연결된 제안 목록 DTO들 (옵셔널)
    * @param options 주소 포함 여부 및 기타 옵션
    * @returns EstimateRequestResponseDto 인스턴스
    */
   static from(
     request: EstimateRequest,
-    offers: EstimateOfferResponseDto[] = [],
+    offers?: EstimateOfferResponseDto[],
     options?: {
       includeAddress?: boolean;
       includeMinimalAddress?: boolean;
@@ -43,8 +43,13 @@ export class EstimateRequestResponseDto {
     dto.createdAt = request.createdAt;
     dto.moveType = request.moveType;
     dto.moveDate = request.moveDate;
-    dto.estimateOffers = offers;
-    dto.offerCount = offers.length;
+
+    // offers가 존재하고 비어있지 않은 경우에만 할당
+    if (offers?.length) {
+      dto.estimateOffers = offers;
+      dto.offerCount = offers.length;
+    }
+
     dto.isTargeted = isTargeted ?? false;
 
     // customer.user.name 설정

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -20,6 +20,7 @@ import {
   ApiGetMyEstimateHistory,
   ApiGetRequestListForMover,
   ApiCancelEstimateRequest,
+  ApiCompleteEstimateRequest,
 } from './docs/swagger';
 import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
 import { EstimateRequestResponseDto } from './dto/estimate-request-response.dto';
@@ -106,6 +107,20 @@ export class EstimateRequestController {
       user.sub,
     );
     return { message: '견적 요청이 성공적으로 취소되었습니다.' };
+  }
+
+  @Patch(':requestId/complete')
+  @RBAC(Role.CUSTOMER)
+  @ApiCompleteEstimateRequest()
+  async completeEstimateRequest(
+    @Param('requestId') requestId: string,
+    @UserInfo() user: UserInfo,
+  ) {
+    await this.estimateRequestService.completeEstimateRequest(
+      requestId,
+      user.sub,
+    );
+    return { message: '이사가 성공적으로 완료 처리되었습니다.' };
   }
 
   // @Delete(':id')

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -31,12 +31,14 @@ export class EstimateRequestController {
   constructor(
     private readonly estimateRequestService: EstimateRequestService,
   ) {}
-  //INFO: 개발용 해당 고객의 진행 중인 견적 요청 ID 조회 API
+  // 고객의 진행 중인 견적 요청 조회 API
   @Get('active')
   @ApiGetMyActiveEstimateRequest()
   @RBAC(Role.CUSTOMER)
-  async getMyActiveEstimateRequest(@UserInfo() user: UserInfo) {
-    return this.estimateRequestService.findActiveEstimateRequestIds(user.sub);
+  async getMyActiveEstimateRequest(
+    @UserInfo() user: UserInfo,
+  ): Promise<EstimateRequestResponseDto[]> {
+    return this.estimateRequestService.findActiveEstimateRequests(user.sub);
   }
 
   @Post()

--- a/src/estimate-request/estimate-request.controller.ts
+++ b/src/estimate-request/estimate-request.controller.ts
@@ -19,6 +19,7 @@ import {
   ApiGetMyActiveEstimateRequest,
   ApiGetMyEstimateHistory,
   ApiGetRequestListForMover,
+  ApiCancelEstimateRequest,
 } from './docs/swagger';
 import { EstimateRequestPaginationDto } from './dto/estimate-request-pagination.dto';
 import { EstimateRequestResponseDto } from './dto/estimate-request-response.dto';
@@ -91,6 +92,20 @@ export class EstimateRequestController {
       user.sub,
       pagination,
     );
+  }
+
+  @Patch(':requestId/cancel')
+  @RBAC(Role.CUSTOMER)
+  @ApiCancelEstimateRequest()
+  async cancelEstimateRequest(
+    @Param('requestId') requestId: string,
+    @UserInfo() user: UserInfo,
+  ) {
+    await this.estimateRequestService.cancelEstimateRequest(
+      requestId,
+      user.sub,
+    );
+    return { message: '견적 요청이 성공적으로 취소되었습니다.' };
   }
 
   // @Delete(':id')


### PR DESCRIPTION
## 🧚 변경사항 설명

- 고객이 이사 완료한 후 Confirmed 상태였던 견적 요청과, 제안의 상태를 Completed로 변경하는 API

## 🧑🏻‍🏫 To-do

- cron으로 이사 날짜 지나면 처리하던 completed 로직 -> 나머지 expired만 시키도록 수정 (?) 

## 🎤 공유 사항

<!-- 기타 팀원들이 참고해야 할 사항이 있으면 작성해주세요  -->

## 🤙🏻 관련 이슈

Closes #119

## 📸 스크린샷
- 고객이 받았던 견적 목록 조회(history) Request와 Offer의 상태가 모두 Confirmed인 건의 estimateRequestId로 아래 견적 요청 ID 조회
![Screenshot 2025-06-27 155951](https://github.com/user-attachments/assets/83c2b3da-b3db-4a42-9547-83a9e605a660)<img width="770" alt="image" src="https://github.com/user-attachments/assets/6f1f8e2a-fa39-4383-8e0f-3efcb3a26c42" />


- 이사 완료하기 실행
![Screenshot 2025-06-27 160919](https://github.com/user-attachments/assets/323f412d-ac5e-490c-a232-6227ce489a67)
![Screenshot 2025-06-27 160945](https://github.com/user-attachments/assets/f9783dcf-1242-4471-9da9-c0fca83924be)

- 받았던 견적 목록 다시 조회시 COMPLETED 상태 변경 확인 <img width="781" alt="image" src="https://github.com/user-attachments/assets/86ce25e2-91fe-4092-ba02-d4cb0901d0b9" />
