### PR TITLE
fix: 견적 제안 알림 customer에게 수정

### DIFF
--- a/src/estimate-offer/estimate-offer.module.ts
+++ b/src/estimate-offer/estimate-offer.module.ts
@@ -10,10 +10,6 @@ import {
   NewEstimateOfferEventDispatcher,
   OfferConfirmEventDispatcher,
 } from '@/notification/events/dispatcher';
-import {
-  NewEstimateOfferListener,
-  OfferConfirmListener,
-} from '@/notification/listeners/listener';
 import { NotificationModule } from '@/notification/notification.module';
 
 @Module({
@@ -29,9 +25,7 @@ import { NotificationModule } from '@/notification/notification.module';
   controllers: [EstimateOfferController],
   providers: [
     EstimateOfferService,
-    //알림에서 사용 하는 dispatcher, listener 모듈
-    OfferConfirmListener,
-    NewEstimateOfferListener,
+    //알림에서 사용 하는 dispatcher만 등록 (listener는 NotificationModule에서 관리)
     OfferConfirmEventDispatcher,
     NewEstimateOfferEventDispatcher,
   ],

--- a/src/estimate-offer/estimate-offer.service.ts
+++ b/src/estimate-offer/estimate-offer.service.ts
@@ -57,6 +57,7 @@ export class EstimateOfferService {
     // 1. 견적 요청 존재 여부 및 상태 확인
     const estimateRequest = await this.requestRepository.findOne({
       where: { id: estimateRequestId },
+      relations: ['customer'],
     });
 
     if (!estimateRequest) {
@@ -105,7 +106,10 @@ export class EstimateOfferService {
     });
 
     //모든 로직이 종료된 후 이벤트 리스너 동작
-    this.newOfferDispatcher.targetMoverAssigned(estimateOffer.id, mover.id);
+    this.newOfferDispatcher.targetMoverAssigned(
+      estimateOffer.id,
+      estimateRequest.customer.id,
+    );
     return await this.offerRepository.save(estimateOffer);
   }
 

--- a/src/estimate-offer/estimate-offer.service.ts
+++ b/src/estimate-offer/estimate-offer.service.ts
@@ -105,12 +105,16 @@ export class EstimateOfferService {
       isConfirmed: false,
     });
 
-    //모든 로직이 종료된 후 이벤트 리스너 동작
+    // 5. 데이터베이스에 먼저 저장
+    const savedEstimateOffer = await this.offerRepository.save(estimateOffer);
+
+    // 6. 저장 완료 후 이벤트 리스너 동작
     this.newOfferDispatcher.targetMoverAssigned(
-      estimateOffer.id,
+      savedEstimateOffer.id,
       estimateRequest.customer.id,
     );
-    return await this.offerRepository.save(estimateOffer);
+
+    return savedEstimateOffer;
   }
 
   /**

--- a/src/notification/events/dispatcher.ts
+++ b/src/notification/events/dispatcher.ts
@@ -35,10 +35,10 @@ export class EstimateRequestEventDispatcher {
 export class NewEstimateOfferEventDispatcher {
   constructor(private readonly eventEmitter: EventEmitter2) {}
 
-  targetMoverAssigned(customerId: string, offerId: string) {
+  targetMoverAssigned(offerId: string, customerId: string) {
     this.eventEmitter.emit(
       'new-estimate-orffer.target-customer-updated',
-      new TargetOfferUpdateEvent(customerId, offerId),
+      new TargetOfferUpdateEvent(offerId, customerId),
     );
   }
 }

--- a/src/notification/notification.module.ts
+++ b/src/notification/notification.module.ts
@@ -6,6 +6,7 @@ import { NotificationService } from './notification.service';
 import { Notification } from './entities/notification.entity';
 import { MoverProfile } from '@/mover-profile/entities/mover-profile.entity';
 import { CustomerProfile } from '@/customer-profile/entities/customer-profile.entity';
+import { EstimateOffer } from '@/estimate-offer/entities/estimate-offer.entity';
 import {
   EstimateRequestListener,
   NewEstimateOfferListener,
@@ -21,6 +22,7 @@ import {
       User,
       MoverProfile,
       CustomerProfile,
+      EstimateOffer,
     ]),
   ],
   controllers: [NotificationController],

--- a/src/notification/notification.service.ts
+++ b/src/notification/notification.service.ts
@@ -57,19 +57,7 @@ export class NotificationService {
         `해당 ID(${createDto.userId})를 가진 유저를 찾을 수 없습니다.`,
       );
     }
-    // 중복 여부 체크
-    const existing = await this.notificationRepo.findOne({
-      where: {
-        user: { id: user.id },
-        type: createDto.type,
-        message: createDto.message,
-        isRead: false, // 안읽은 알림 중 같은 알림이 있는 경우만 체크
-      },
-    });
 
-    if (existing) {
-      return { message: '이미 동일한 알림이 존재합니다.' };
-    }
     // 알림 생성
     const notification = this.notificationRepo.create({
       type: createDto.type,

--- a/test/utils/test-helpers.ts
+++ b/test/utils/test-helpers.ts
@@ -251,7 +251,7 @@ export const getRandomAddress = () =>
   addressData[Math.floor(Math.random() * addressData.length)];
 
 // 리뷰 관련 상수
-const REVIEW_RATINGS = [3, 3.5, 4, 4.5, 5] as const;
+const REVIEW_RATINGS = [1, 2, 3, 4, 5] as const;
 const REVIEW_COMMENTS = [
   '이사 서비스가 매우 만족스러웠습니다.',
   '기사님이 매우 친절하셨고 꼼꼼하게 작업해주셨어요.',
@@ -284,3 +284,36 @@ export const generateRandomMoveType = (): ServiceType => {
   const moveTypes = Object.values(ServiceType);
   return getRandomElement(moveTypes);
 };
+
+// 기사님 닉네임 리스트
+const moverNicknames = [
+  '무빙맨',
+  '이사왕',
+  '이사천재',
+  '짐박사',
+  '포장이사달인',
+  '이사마스터',
+  '짐운반장인',
+  '이사도우미',
+  '이사프로',
+  '이사특공대',
+];
+
+// 순차 이메일 생성 함수 (ex: mover01@moving.com, customer02@moving.com)
+export function generateSequentialEmail(
+  role: 'mover' | 'customer',
+  index: number,
+) {
+  return `${role}${String(index).padStart(2, '0')}@moving.com`;
+}
+
+// 닉네임 생성 함수 (ex: 빠른치타01, 행복한고객01)
+export function generateNickname(role: 'mover' | 'customer', index: number) {
+  if (role === 'mover') {
+    const base = moverNicknames[index % moverNicknames.length];
+    return `${base}${String(index + 1).padStart(2, '0')}`;
+  } else {
+    // 고객은 랜덤 한국식 이름 사용
+    return generateKoreanName();
+  }
+}


### PR DESCRIPTION
## 🧚 변경사항 설명

- 기사가 견적 제안 생성시 고객에게 알림 가도록 수정
- estimateOffer 의존성 주입하여 estimateOffer.mover.nickname로 기사님이름도 알림에 포함시키도록 수정
- 중복 알림 제거 로직을 제거. 기사님 이름이 추가되므로 각 견적 제안 알림의 메시지가 모두 달라짐

## 🧑🏻‍🏫 To-do

<!-- 추가로 작업해야 할 항목이 있으면 체크 박스 리스트로 정리해주세요 -->

## 🎤 공유 사항

<!-- 기타 팀원들이 참고해야 할 사항이 있으면 작성해주세요  -->

## 🤙🏻 관련 이슈

<!-- 이 PR이 해결하는 이슈 번호를 입력해주세요 -->

Closes #

## 📸 스크린샷
![image](https://github.com/user-attachments/assets/68d413e3-d740-4fa2-963f-3b46adc4b70e)

